### PR TITLE
Apply changed plugin name to settings panel; Trim down printer screen…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Apply changed plugin name to settings panel
+- Trim down printer screen to fit all text
 
 ## [2.0.0] - 2021-01-29
 ### Changed

--- a/octoprint_display_panel/__init__.py
+++ b/octoprint_display_panel/__init__.py
@@ -785,8 +785,8 @@ class Display_panelPlugin(octoprint.plugin.StartupPlugin,
 					tool = temperatures['tool0'] or None
 					bed = temperatures['bed'] or None
 
-					self.draw.text((left, top + offset + 9), "Head: %s / %s \xb0C" % (tool['actual'], tool['target']), font=self.font, fill=255)
-					self.draw.text((left, top + offset + 18), " Bed: %s / %s \xb0C" % (bed['actual'], bed['target']), font=self.font, fill=255)
+					self.draw.text((left, top + offset + 9), "Head: %s / %s\xb0C" % (tool['actual'], tool['target']), font=self.font, fill=255)
+					self.draw.text((left, top + offset + 18), " Bed: %s / %s\xb0C" % (bed['actual'], bed['target']), font=self.font, fill=255)
 			except Exception as ex:
 				self.log_error(ex)
 

--- a/octoprint_display_panel/templates/display_panel_settings.jinja2
+++ b/octoprint_display_panel/templates/display_panel_settings.jinja2
@@ -1,6 +1,6 @@
 <form id="settings_display_panel" class="form-horizontal">
 	<div class="tabbable">
-		<h4>{{ _('Display Panel Plugin') }}</h4>
+		<h4>{{ _('Micro Panel Plugin') }}</h4>
 
 		<ul class="nav nav-tabs" id="display_panel_tabs">
 			<li class="active"><a data-toggle="tab" href="#display_panel_buttons">Buttons</a></li>


### PR DESCRIPTION
… to fit all text

Signed-off-by: Jörg Eichhorn <joerg.eichhorn@unclej.de>

## Description
The settings dialog was still showing the previous plugin name so the string got updated. Additionally the blank between the temperatures and the degrees sign was removed (the celsius sign was cut off for temperatures greater or equal 100 degrees Celsius)

## Checklist

- [x] Commit message describes the changes
- [x] Updated CHANGELOG.md "Unreleased" section with changes
