### PR TITLE
Log and ignore errors in check_system_stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Trap and log errors in retrieving system stats to avoid getting stuck in "Gathering System Stats"
 
 ## [2.0.1] - 2021-02-07
 ### Changed

--- a/octoprint_display_panel/__init__.py
+++ b/octoprint_display_panel/__init__.py
@@ -379,20 +379,23 @@ class Display_panelPlugin(octoprint.plugin.StartupPlugin,
 		Called by the system check timer on a regular basis. This function should remain small,
 		performant and not block.
 		"""
+		try:
+			if self._screen_mode == ScreenModes.SYSTEM:
+				s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+				s.connect(("8.8.8.8", 80))
+				self._system_stats['ip'] = s.getsockname()[0]
+				s.close()
+				self._system_stats['load'] = psutil.getloadavg()
+				self._system_stats['memory'] = psutil.virtual_memory()
+				self._system_stats['disk'] = shutil.disk_usage('/') # disk percentage = 100 * used / (used + free)
 
-		if self._screen_mode == ScreenModes.SYSTEM:
-			s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-			s.connect(("8.8.8.8", 80))
-			self._system_stats['ip'] = s.getsockname()[0]
-			s.close()
-			self._system_stats['load'] = psutil.getloadavg()
-			self._system_stats['memory'] = psutil.virtual_memory()
-			self._system_stats['disk'] = shutil.disk_usage('/') # disk percentage = 100 * used / (used + free)
-
-			self.update_ui()
-		elif self._screen_mode == ScreenModes.PRINTER:
-			# Just update the UI, the printer mode will take care of itself
-			self.update_ui()
+				self.update_ui()
+			elif self._screen_mode == ScreenModes.PRINTER:
+				# Just update the UI, the printer mode will take care of itself
+				self.update_ui()
+		except Exception as ex:
+			self.log_error(ex)
+			pass
 
 	def setup_display(self):
 		"""


### PR DESCRIPTION
## Description

If OctoPrint starts up before networking is fully available, the following message is displayed and the plugin does not startup successfully:

```
2021-02-22 11:50:47,641 - octoprint.plugin - ERROR - Error while calling plugin display_panel
Traceback (most recent call last):
  File "/home/pi/oprint/lib/python3.7/site-packages/octoprint/plugin/__init__.py", line 271, in call_plugin
    result = getattr(plugin, method)(*args, **kwargs)
  File "/home/pi/oprint/lib/python3.7/site-packages/octoprint/util/__init__.py", line 1890, in wrapper
    return f(*args, **kwargs)
  File "/home/pi/oprint/lib/python3.7/site-packages/octoprint_display_panel/__init__.py", line 91, in on_after_startup
    self.check_system_stats()
  File "/home/pi/oprint/lib/python3.7/site-packages/octoprint_display_panel/__init__.py", line 385, in check_system_stat
s
    s.connect(("8.8.8.8", 80))
OSError: [Errno 101] Network is unreachable
```

This PR wraps the `check_system_stats()` function in a try-except block, similar to other functions in the plugin, to log and ignore the error.

## Checklist

- [x] Commit message describes the changes
- [x] Updated CHANGELOG.md "Unreleased" section with changes
