### PR TITLE
Add "connect" and "start" functions to Play button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Play button now can be used to connect to a disconnected printer and start a queued job
 
 ## [2.0.1] - 2021-02-07
 ### Changed

--- a/octoprint_display_panel/__init__.py
+++ b/octoprint_display_panel/__init__.py
@@ -576,9 +576,13 @@ class Display_panelPlugin(octoprint.plugin.StartupPlugin,
 
 	def try_play(self):
 		"""
-		If possible, play or resume a print
+		If printer is not connected, try to connect to it.
+		Otherwise, if possible, play or resume a print
 		"""
 
+		if self._printer.get_current_connection()[0] == "Closed":
+			self._printer.connect()
+		
 		# TODO: If a print is queued up and ready, start it
 		if not self._printer.is_paused():
 			return


### PR DESCRIPTION
## Description

My printer is usually powered off when I first send a job to OctoPrint, so the ability to have a small control panel to both re-establish a connection and start a queued job is very valuable to me. This PR adds both of these functions:

* When the printer is disconnected, pushing Play will attempt to connect to it
* When there is a print job selected, pushing Play will start the job

## Checklist

- [x] Commit message describes the changes
- [x] Updated CHANGELOG.md "Unreleased" section with changes
