### PR TITLE
fix(color): update the height of the bi-color section. fixes #49

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixes
+- Fix off-by-one issue with bi-color section on display
+
 ## [2.1.0] - 2021-02-28
 ### Changed
 - Add missing dependency for RPi.GPIO (unclej84)

--- a/octoprint_display_panel/__init__.py
+++ b/octoprint_display_panel/__init__.py
@@ -42,7 +42,7 @@ class Display_panelPlugin(octoprint.plugin.StartupPlugin,
 	_area_offset = 3
 	_cancel_requested_at = 0
 	_cancel_timer = None
-	_colored_strip_height = 16 # height of colored strip on top for dual color display
+	_colored_strip_height = 15 # height of colored strip on top for dual color display
 	_debounce = 0
 	_display_init = False
 	_displaylayerprogress_current_height = -1.0


### PR DESCRIPTION
## Description

They say there are two hard problems in computer science: cacheing and naming things... and off-by-one errors.
This fixes a 1-pixel overflow that happens on the progress bar, particularly visible on bi-color displays.

## Checklist

- [x] Commit message describes the changes
- [x] Updated CHANGELOG.md "Unreleased" section with changes
