### PR TITLE
Refactoring: Modular screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Refactoring: Modularized display screens for future expansion (kgutwin)
 
 ## [2.1.1] - 2021-03-04
 ### Fixes

--- a/octoprint_display_panel/__init__.py
+++ b/octoprint_display_panel/__init__.py
@@ -20,6 +20,41 @@ import inspect
 import adafruit_ssd1306
 import RPi.GPIO as GPIO
 
+## REFACTORING SCOPES
+##   Changes to the following are scoped to a specific branch, and should
+##   not be modified by another branch. Conflicting changes should be done
+##   in the top-level refactor branch.
+##
+## refactor/virtual-panel
+##   - setup_display(), clear_display()
+##   - setup_gpio(), configure_gpio(), configure_single_gpio(), clean_gpio()
+##   - handle_gpio_event()
+##   - initialize(), get_settings_defaults(), on_settings_save()
+##   - bcm2board()
+##   - start_display_timer(), stop_display_timer(), trigger_display_timeout()
+## refactor/modular-screens
+##   - handle_button_press()
+##   - next_mode(), try_cancel(), clear_cancel(), try_play(), try_pause()
+##   - update_ui() and all other update_ui_***()
+##   - _screen_mode, ScreenModes
+##   - on_event(), on_print_progress(), on_slicing_progress()
+##   - start_system_timer(), check_system_stats()
+##   - set_printer_state()
+
+## COMMON INTERFACE
+##   The following shall be stable from the top-level refactor branch.
+##
+## Display_panelPlugin.disp
+##   - disp.width, disp.height
+##   - disp.fill(n)
+##   - disp.show()
+##   - disp.poweroff(), disp.poweron()
+##   - disp.image(img)
+## Display_panelPlugin.handle_button_press(label)
+## Display_panelPlugin.update_ui()
+## Display_panelPlugin.start_system_timer()
+## Display_panelPlugin.start_display_timer(reconfigure)
+
 class ScreenModes(Enum):
 	PRINT = 1
 	PRINTER = 2
@@ -519,18 +554,30 @@ class Display_panelPlugin(octoprint.plugin.StartupPlugin,
 				else:
 					self.start_display_timer()
 				label = self.input_pinset[channel]
-				if label == 'cancel':
-					self.try_cancel()
+
+				self.handle_button_press(label)
+		except Exception as ex:
+			self.log_error(ex)
+			pass
+
+	def handle_button_press(self, label):
+		"""
+		Take action on a button press with the given name (such as 'cancel' or 'play')
+		"""
+
+		try:
+			if label == 'cancel':
+				self.try_cancel()
+			else:
+				if self._cancel_timer is not None:
+					self.clear_cancel()
 				else:
-					if self._cancel_timer is not None:
-						self.clear_cancel()
-					else:
-						if label == 'mode':
-							self.next_mode()
-						if label == 'play':
-							self.try_play()
-						if label == 'pause':
-							self.try_pause()
+					if label == 'mode':
+						self.next_mode()
+					if label == 'play':
+						self.try_play()
+					if label == 'pause':
+						self.try_pause()
 		except Exception as ex:
 			self.log_error(ex)
 			pass

--- a/octoprint_display_panel/__init__.py
+++ b/octoprint_display_panel/__init__.py
@@ -120,6 +120,7 @@ class Display_panelPlugin(octoprint.plugin.StartupPlugin,
 		"""
 
 		self.setup_display()
+		self.setup_screens()
 		self.setup_gpio()
 		self.configure_gpio()
 		self.clear_display()
@@ -148,52 +149,56 @@ class Display_panelPlugin(octoprint.plugin.StartupPlugin,
 
 		# self._logger.info("on_event: %s", event)
 
+		result = self.top_screen.process_event(event, payload)
+		if 'DRAW' in result:
+			self.update_ui()
+		
 		self.set_printer_state(event)
-
-		# Connectivity
-		if event == Events.DISCONNECTED:
-			self._screen_mode = ScreenModes.SYSTEM
-
-		if event in (Events.CONNECTED, Events.CONNECTING, Events.CONNECTIVITY_CHANGED,
-								 Events.DISCONNECTING):
-			self.update_ui()
-
-		# Print start display
-		if event == Events.PRINT_STARTED:
-			self._screen_mode = ScreenModes.PRINT
-			self.update_ui()
-
-		# Print end states
-		if event in (Events.PRINT_FAILED, Events.PRINT_DONE, Events.PRINT_CANCELLED,
-								 Events.PRINT_CANCELLING):
-			self._displaylayerprogress_current_height = -1.0
-			self._displaylayerprogress_current_layer = -1
-			self._displaylayerprogress_total_height = -1.0
-			self._displaylayerprogress_total_layer = -1
-			self.update_ui()
-
-		# Print limbo states
-		if event in (Events.PRINT_PAUSED, Events.PRINT_RESUMED):
-			self.update_ui()
-
-		# Mid-print states
-		if event in (Events.Z_CHANGE, Events.PRINTER_STATE_CHANGED):
-			self.update_ui()
-
-		# Get progress information from DisplayLayerProgress plugin
-		if event in ("DisplayLayerProgress_heightChanged",
-						"DisplayLayerProgress_layerChanged"):
-			if payload.get('currentHeight') != "-":
-				self._displaylayerprogress_current_height = float(payload.get('currentHeight'))
-			else:
-				self._displaylayerprogress_current_height = -1.0
-			if payload.get('currentLayer') != "-":
-				self._displaylayerprogress_current_layer = int(payload.get('currentLayer'))
-			else:
-				self._displaylayerprogress_current_layer = -1
-			self._displaylayerprogress_total_height = float(payload.get('totalHeight'))
-			self._displaylayerprogress_total_layer = int(payload.get('totalLayer'))
-			self.update_ui()
+#
+#		# Connectivity
+#		if event == Events.DISCONNECTED:
+#			self._screen_mode = ScreenModes.SYSTEM
+#
+#		if event in (Events.CONNECTED, Events.CONNECTING, Events.CONNECTIVITY_CHANGED,
+#								 Events.DISCONNECTING):
+#			self.update_ui()
+#
+#		# Print start display
+#		if event == Events.PRINT_STARTED:
+#			self._screen_mode = ScreenModes.PRINT
+#			self.update_ui()
+#
+#		# Print end states
+#		if event in (Events.PRINT_FAILED, Events.PRINT_DONE, Events.PRINT_CANCELLED,
+#								 Events.PRINT_CANCELLING):
+#			self._displaylayerprogress_current_height = -1.0
+#			self._displaylayerprogress_current_layer = -1
+#			self._displaylayerprogress_total_height = -1.0
+#			self._displaylayerprogress_total_layer = -1
+#			self.update_ui()
+#
+#		# Print limbo states
+#		if event in (Events.PRINT_PAUSED, Events.PRINT_RESUMED):
+#			self.update_ui()
+#
+#		# Mid-print states
+#		if event in (Events.Z_CHANGE, Events.PRINTER_STATE_CHANGED):
+#			self.update_ui()
+#
+#		# Get progress information from DisplayLayerProgress plugin
+#		if event in ("DisplayLayerProgress_heightChanged",
+#						"DisplayLayerProgress_layerChanged"):
+#			if payload.get('currentHeight') != "-":
+#				self._displaylayerprogress_current_height = float(payload.get('currentHeight'))
+#			else:
+#				self._displaylayerprogress_current_height = -1.0
+#			if payload.get('currentLayer') != "-":
+#				self._displaylayerprogress_current_layer = int(payload.get('currentLayer'))
+#			else:
+#				self._displaylayerprogress_current_layer = -1
+#			self._displaylayerprogress_total_height = float(payload.get('totalHeight'))
+#			self._displaylayerprogress_total_layer = int(payload.get('totalLayer'))
+#			self.update_ui()
 
 	##~~ ProgressPlugin mixin
 
@@ -403,9 +408,9 @@ class Display_panelPlugin(octoprint.plugin.StartupPlugin,
 		"""
 		Function to check system stats periodically
 		"""
-
-		self._check_system_timer = RepeatedTimer(5, self.check_system_stats, None, None, True)
-		self._check_system_timer.start()
+		pass
+#		self._check_system_timer = RepeatedTimer(5, self.check_system_stats, None, None, True)
+#		self._check_system_timer.start()
 
 	def check_system_stats(self):
 		"""
@@ -414,23 +419,24 @@ class Display_panelPlugin(octoprint.plugin.StartupPlugin,
 		Called by the system check timer on a regular basis. This function should remain small,
 		performant and not block.
 		"""
-		try:
-			if self._screen_mode == ScreenModes.SYSTEM:
-				s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-				s.connect(("8.8.8.8", 80))
-				self._system_stats['ip'] = s.getsockname()[0]
-				s.close()
-				self._system_stats['load'] = psutil.getloadavg()
-				self._system_stats['memory'] = psutil.virtual_memory()
-				self._system_stats['disk'] = shutil.disk_usage('/') # disk percentage = 100 * used / (used + free)
-
-				self.update_ui()
-			elif self._screen_mode == ScreenModes.PRINTER:
-				# Just update the UI, the printer mode will take care of itself
-				self.update_ui()
-		except Exception as ex:
-			self.log_error(ex)
-			pass
+		pass
+#		try:
+#			if self._screen_mode == ScreenModes.SYSTEM:
+#				s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+#				s.connect(("8.8.8.8", 80))
+#				self._system_stats['ip'] = s.getsockname()[0]
+#				s.close()
+#				self._system_stats['load'] = psutil.getloadavg()
+#				self._system_stats['memory'] = psutil.virtual_memory()
+#				self._system_stats['disk'] = shutil.disk_usage('/') # disk percentage = 100 * used / (used + free)
+#
+#				self.update_ui()
+#			elif self._screen_mode == ScreenModes.PRINTER:
+#				# Just update the UI, the printer mode will take care of itself
+#				self.update_ui()
+#		except Exception as ex:
+#			self.log_error(ex)
+#			pass
 
 	def setup_display(self):
 		"""
@@ -560,99 +566,109 @@ class Display_panelPlugin(octoprint.plugin.StartupPlugin,
 			self.log_error(ex)
 			pass
 
+	def setup_screens(self):
+		"""Create the top level screen.
+		"""
+		self.top_screen = screens.MicroPanelScreenTop(self.width,
+							      self.height)
+		
+		
 	def handle_button_press(self, label):
 		"""
 		Take action on a button press with the given name (such as 'cancel' or 'play')
 		"""
-
-		try:
-			if label == 'cancel':
-				self.try_cancel()
-			else:
-				if self._cancel_timer is not None:
-					self.clear_cancel()
-				else:
-					if label == 'mode':
-						self.next_mode()
-					if label == 'play':
-						self.try_play()
-					if label == 'pause':
-						self.try_pause()
-		except Exception as ex:
-			self.log_error(ex)
-			pass
-
-	def next_mode(self):
-		"""
-		Go to the next screen mode
-		"""
-
-		self._screen_mode = self._screen_mode.next()
-		self.update_ui()
-
-	def try_cancel(self):
-		"""
-		First click, confirm cancellation. Second click, trigger cancel
-		"""
-
-		if not self._printer.is_printing() and not self._printer.is_paused():
-			return
-
-		if self._cancel_timer:
-			# GPIO can double-trigger sometimes, check if this is too fast and ignore
-			if (time.time() - self._cancel_requested_at) < 1:
-				return
-
-			# Cancel has been tried, run a cancel
-			self.clear_cancel()
-			self._printer.cancel_print()
-		else:
-			# First press
-			self._cancel_requested_at = time.time()
-			self._cancel_timer = RepeatedTimer(10, self.clear_cancel, run_first=False)
-			self._cancel_timer.start()
+		result = self.top_screen.process_button(label)
+		if 'DRAW' in result:
 			self.update_ui()
-
-	def clear_cancel(self):
-		"""
-		Clear a pending cancel, something else was clicked or a timeout occured
-		"""
-
-		if self._cancel_timer:
-			self._cancel_timer.cancel()
-			self._cancel_timer = None
-			self._cancel_requested_at = 0
-			self.update_ui()
-
-	def try_play(self):
-		"""
-		If printer is not connected, try to connect to it.
-		Otherwise, if possible, play or resume a print
-		"""
-
-		if self._printer.get_current_connection()[0] == "Closed":
-			self._printer.connect()
-			return
-
-		current_data = self._printer.get_current_data()
-		if current_data['state']['flags']['ready'] and (current_data['progress']['completion'] or 0) == 0 and current_data['job']['file']['name']:
-			self._printer.start_print()
-			return
-
-		if not self._printer.is_paused():
-			return
-
-		self._printer.resume_print()
-
-	def try_pause(self):
-		"""
-		If possible, pause a running print
-		"""
-
-		if not self._printer.is_printing():
-			return
-
-		self._printer.pause_print()
+		
+#		try:
+#			if label == 'cancel':
+#				self.try_cancel()
+#			else:
+#				if self._cancel_timer is not None:
+#					self.clear_cancel()
+#				else:
+#					if label == 'mode':
+#						self.next_mode()
+#					if label == 'play':
+#						self.try_play()
+#					if label == 'pause':
+#						self.try_pause()
+#		except Exception as ex:
+#			self.log_error(ex)
+#			pass
+#
+#	def next_mode(self):
+#		"""
+#		Go to the next screen mode
+#		"""
+#
+#		self._screen_mode = self._screen_mode.next()
+#		self.update_ui()
+#
+#	def try_cancel(self):
+#		"""
+#		First click, confirm cancellation. Second click, trigger cancel
+#		"""
+#
+#		if not self._printer.is_printing() and not self._printer.is_paused():
+#			return
+#
+#		if self._cancel_timer:
+#			# GPIO can double-trigger sometimes, check if this is too fast and ignore
+#			if (time.time() - self._cancel_requested_at) < 1:
+#				return
+#
+#			# Cancel has been tried, run a cancel
+#			self.clear_cancel()
+#			self._printer.cancel_print()
+#		else:
+#			# First press
+#			self._cancel_requested_at = time.time()
+#			self._cancel_timer = RepeatedTimer(10, self.clear_cancel, run_first=False)
+#			self._cancel_timer.start()
+#			self.update_ui()
+#
+#	def clear_cancel(self):
+#		"""
+#		Clear a pending cancel, something else was clicked or a timeout occured
+#		"""
+#
+#		if self._cancel_timer:
+#			self._cancel_timer.cancel()
+#			self._cancel_timer = None
+#			self._cancel_requested_at = 0
+#			self.update_ui()
+#
+#	def try_play(self):
+#		"""
+#		If printer is not connected, try to connect to it.
+#		Otherwise, if possible, play or resume a print
+#		"""
+#
+#		if self._printer.get_current_connection()[0] == "Closed":
+#			self._printer.connect()
+#			return
+#
+#		current_data = self._printer.get_current_data()
+#		if current_data['state']['flags']['ready'] and (current_data['progress']['completion'] or 0) == 0 and current_data['job']['file']['name']:
+#			self._printer.start_print()
+#			return
+#
+#		if not self._printer.is_paused():
+#			return
+#
+#		self._printer.resume_print()
+#
+#	def try_pause(self):
+#		"""
+#		If possible, pause a running print
+#		"""
+#
+#		if not self._printer.is_printing():
+#			return
+#
+#		self._printer.pause_print()
 
 	def clear_display(self):
 		"""
@@ -739,19 +755,21 @@ class Display_panelPlugin(octoprint.plugin.StartupPlugin,
 
 		if self._display_init:
 			try:
-				current_data = self._printer.get_current_data()
+#				current_data = self._printer.get_current_data()
+#
+#				if self._cancel_timer is not None and current_data['state']['flags']['cancelling'] is False:
+#					self.update_ui_cancel_confirm()
+#				elif self._screen_mode == ScreenModes.SYSTEM:
+#					self.update_ui_system()
+#				elif self._screen_mode == ScreenModes.PRINTER:
+#					self.update_ui_printer()
+#				elif self._screen_mode == ScreenModes.PRINT:
+#					self.update_ui_print(current_data)
+#
+#				self.update_ui_bottom(current_data)
 
-				if self._cancel_timer is not None and current_data['state']['flags']['cancelling'] is False:
-					self.update_ui_cancel_confirm()
-				elif self._screen_mode == ScreenModes.SYSTEM:
-					self.update_ui_system()
-				elif self._screen_mode == ScreenModes.PRINTER:
-					self.update_ui_printer()
-				elif self._screen_mode == ScreenModes.PRINT:
-					self.update_ui_print(current_data)
-
-				self.update_ui_bottom(current_data)
-
+				self.image = self.top_screen.image
+				
 				# Display image.
 				if self._image_rotate:
 					self.disp.image(self.image.rotate(angle=180))
@@ -761,218 +779,218 @@ class Display_panelPlugin(octoprint.plugin.StartupPlugin,
 			except Exception as ex:
 				self.log_error(ex)
 
-	def update_ui_cancel_confirm(self):
-		"""
-		Show a confirmation message that a cancel print has been requested
-		"""
-
-		top = (self._colored_strip_height) * int(self._progress_on_top)
-		bottom = self.height - (self._colored_strip_height * int(not self._progress_on_top))
-		left = 0
-		offset = self._area_offset * int(self._progress_on_top)
-
-		if self._display_init:
-			try:
-				self.draw.rectangle((0, top, self.width, bottom), fill=0)
-
-				display_string = "Cancel Print?"
-				text_width = self.draw.textsize(display_string, font=self.font)[0]
-				self.draw.text((self.width / 2 - text_width / 2, top + offset + 0), display_string, font=self.font, fill=255)
-				display_string = "Press 'X' to confirm"
-				text_width = self.draw.textsize(display_string, font=self.font)[0]
-				self.draw.text((self.width / 2 - text_width / 2, top + offset + 9), display_string, font=self.font, fill=255)
-				display_string = "Press any button or"
-				text_width = self.draw.textsize(display_string, font=self.font)[0]
-				self.draw.text((self.width / 2 - text_width / 2, top + offset + 18), display_string, font=self.font, fill=255)
-				display_string = "wait 10 sec to escape"
-				text_width = self.draw.textsize(display_string, font=self.font)[0]
-				self.draw.text((self.width / 2 - text_width / 2, top + offset + 27), display_string, font=self.font, fill=255)
-			except Exception as ex:
-				self.log_error(ex)
-
-
-	def update_ui_system(self):
-		"""
-		Update three-fourths of the screen with system stats collected by the timed collector
-		"""
-
-		if self._display_init:
-			top = (self._colored_strip_height) * int(self._progress_on_top)
-			bottom = self.height - (self._colored_strip_height * int(not self._progress_on_top))
-			left = 0
-			offset = self._area_offset * int(self._progress_on_top)
-
-			# Draw a black filled box to clear the image.
-			self.draw.rectangle((0, top, self.width, bottom), fill=0)
-
-			try:
-				mem = self._system_stats['memory']
-				disk = self._system_stats['disk']
-
-				# Center IP
-				ip = self._system_stats['ip']
-				tWidth, tHeight = self.draw.textsize(ip)
-				self.draw.text((left + ((self.width - tWidth) / 2), top + offset + 0), ip, font=self.font, fill=255)
-
-				# System Stats
-				self.draw.text((left, top + offset + 9), "L: %s, %s, %s" % self._system_stats['load'], font=self.font, fill=255)
-				self.draw.text((left, top + offset + 18), "M: %s/%s MB %s%%" % (int(mem.used/1048576), int(mem.total/1048576), mem.percent), font=self.font, fill=255)
-				self.draw.text((left, top + offset + 27), "D: %s/%s GB %s%%" % (int(disk.used/1073741824), int((disk.used+disk.total)/1073741824), int(10000*disk.used/(disk.used+disk.free))/100), font=self.font, fill=255)
-			except:
-				self.draw.text((left, top + offset + 9), "Gathering System Stats", font=self.font, fill=255)
-
-	def update_ui_printer(self):
-		"""
-		Update three-fourths of the screen with stats about the printer, such as temperatures
-		"""
-
-		if self._display_init:
-			top = (self._colored_strip_height) * int(self._progress_on_top)
-			bottom = self.height - (self._colored_strip_height * int(not self._progress_on_top))
-			left = 0
-			offset = self._area_offset * int(self._progress_on_top)
-
-			try:
-				self.draw.rectangle((0, top, self.width, bottom), fill=0)
-				self.draw.text((left, top + offset + 0), "Printer Temperatures", font=self.font, fill=255)
-
-				if self._printer.get_current_connection()[0] == "Closed":
-					self.draw.text((left, top + offset + 9), "Head: no printer", font=self.font, fill=255)
-					self.draw.text((left, top + offset + 18), " Bed: no printer", font=self.font, fill=255)
-				else:
-					temperatures = self._printer.get_current_temperatures()
-					tool = temperatures['tool0'] or None
-					bed = temperatures['bed'] or None
-
-					self.draw.text((left, top + offset + 9), "Head: %s / %s\xb0C" % (tool['actual'], tool['target']), font=self.font, fill=255)
-					self.draw.text((left, top + offset + 18), " Bed: %s / %s\xb0C" % (bed['actual'], bed['target']), font=self.font, fill=255)
-			except Exception as ex:
-				self.log_error(ex)
-
-	def update_ui_print(self, current_data):
-		"""
-		Update three-fourths of the screen with information about the current ongoing print
-		"""
-
-		if self._display_init:
-			top = (self._colored_strip_height) * int(self._progress_on_top)
-			bottom = self.height - (self._colored_strip_height * int(not self._progress_on_top))
-			left = 0
-			offset = self._area_offset * int(self._progress_on_top)
-
-			try:
-				self.draw.rectangle((0, top, self.width, bottom), fill=0)
-				self.draw.text((left, top + offset + 0), "State: %s" % (self._printer.get_state_string()), font=self.font, fill=255)
-
-				if current_data['job']['file']['name']:
-					file_name = current_data['job']['file']['name']
-					self.draw.text((left, top + offset + 9), "File: %s" % (file_name), font=self.font, fill=255)
-
-					print_time = self._get_time_from_seconds(current_data['progress']['printTime'] or 0)
-					self.draw.text((left, top + offset + 18), "Time: %s" % (print_time), font=self.font, fill=255)
-
-					filament = current_data['job']['filament']['tool0'] if "tool0" in current_data['job']['filament'] else current_data['job']['filament']
-					filament_length = self.float_count_formatter((filament['length'] or 0) / 1000, 3)
-					filament_mass = self.float_count_formatter(filament['volume'] or 0, 3)
-					self.draw.text((left, top + offset + 27), "Filament: %sm/%scm3" % (filament_length, filament_mass), font=self.font, fill=255)
-
-					# Display height if information available from DisplayLayerProgress plugin
-					height = "{:>5.1f}/{:>5.1f}".format(float(self._displaylayerprogress_current_height), float(self._displaylayerprogress_total_height))
-					layer = "{:>4d}/{:>4d}".format(self._displaylayerprogress_current_layer, self._displaylayerprogress_total_layer)
-					height_text = ""
-					if self._displaylayerprogress_current_height != -1.0 and self._displaylayerprogress_current_layer != -1:
-						height_text = layer + ";" + height
-					elif self._displaylayerprogress_current_layer != -1:
-						height_text = layer
-					elif self._displaylayerprogress_current_height != -1.0:
-						height_text = height
-					self.draw.text((left, top + offset + 36), height_text, font=self.font, fill=255)
-				else:
-					self.draw.text((left, top + offset + 18), "Waiting for file...", font=self.font, fill=255)
-			except Exception as ex:
-				self.log_error(ex)
-
-	def update_ui_bottom(self, current_data):
-		"""
-		Update one-fourths of the screen with persistent information about the current print
-		"""
-
-		if self._display_init:
-			top = (self.height - self._colored_strip_height) * int(not self._progress_on_top)
-			bottom = self.height - ((self.height - self._colored_strip_height) * int(self._progress_on_top))
-			left = 0
-
-			try:
-				# Clear area
-				self.draw.rectangle((0, top, self.width, bottom), fill=0)
-				display_string = ""
-				if self._printer.get_current_connection()[0] == "Closed":
-					# Printer isn't connected
-					display_string = "Printer Not Connected"
-				elif current_data['state']['flags']['paused'] or current_data['state']['flags']['pausing']:
-					# Printer paused
-					display_string = "Paused"
-				elif current_data['state']['flags']['cancelling']:
-					# Printer paused
-					display_string = "Cancelling"
-				elif current_data['state']['flags']['ready'] and (current_data['progress']['completion'] or 0) < 100:
-					# Printer connected, not printing
-					if current_data['job']['file']['name']:
-						display_string = "Ready to Start"
-					else:
-						display_string = "Waiting For Job"
-
-				if display_string:
-					text_width = self.draw.textsize(display_string, font=self.font)[0]
-					self.draw.text((self.width / 2 - text_width / 2, top + 4), display_string, font=self.font, fill=255)
-
-				else:
-					percentage = int(current_data['progress']['completion'] or 0)
-					# Calculate progress from time
-					if current_data['progress']['printTime'] and self._timebased_progress:
-						percentage = int((current_data['progress']['printTime'] or 0) / ((current_data['progress']['printTime'] or 0) + current_data['progress']['printTimeLeft']) * 100)
-					time_left = current_data['progress']['printTimeLeft'] or 0
-
-					# Progress bar
-					self.draw.rectangle((0, top + 0, self.width - 1, top + 5), fill=0, outline=255, width=1)
-					bar_width = int((self.width - 5) * percentage / 100)
-					self.draw.rectangle((2, top + 2, bar_width, top + 3), fill=255, outline=255, width=1)
-
-					# Percentage and ETA
-					self.draw.text((0, top + 5), "%s%%" % (percentage), font=self.font, fill=255)
-					eta = time.strftime(self._eta_strftime, time.localtime(time.time() + time_left))
-					eta_width = self.draw.textsize(eta, font=self.font)[0]
-					self.draw.text((self.width - eta_width, top + 5), eta, font=self.font, fill=255)
-			except Exception as ex:
-				self.log_error(ex)
-
-	# Taken from tpmullan/OctoPrint-DetailedProgress
-	def _get_time_from_seconds(self, seconds):
-		hours = 0
-		minutes = 0
-
-		if seconds >= 3600:
-			hours = int(seconds / 3600)
-			seconds = seconds % 3600
-
-		if seconds >= 60:
-			minutes = int(seconds / 60)
-			seconds = seconds % 60
-
-		return self._etl_format.format(**locals())
-
-	def float_count_formatter(self, number, max_chars):
-		"""
-		Show decimals up to a max number of characters, then flips over and rounds to integer
-		"""
-
-		int_part = "%i" % round(number)
-		if len(int_part) >= max_chars - 1:
-			return int_part
-		elif len("%f" % number) <= max_chars:
-			return "%f" % number
-		else:
-			return "{num:0.{width}f}".format(num=number, width=len(int_part) - 1)
+#	def update_ui_cancel_confirm(self):
+#		"""
+#		Show a confirmation message that a cancel print has been requested
+#		"""
+#
+#		top = (self._colored_strip_height) * int(self._progress_on_top)
+#		bottom = self.height - (self._colored_strip_height * int(not self._progress_on_top))
+#		left = 0
+#		offset = self._area_offset * int(self._progress_on_top)
+#
+#		if self._display_init:
+#			try:
+#				self.draw.rectangle((0, top, self.width, bottom), fill=0)
+#
+#				display_string = "Cancel Print?"
+#				text_width = self.draw.textsize(display_string, font=self.font)[0]
+#				self.draw.text((self.width / 2 - text_width / 2, top + offset + 0), display_string, font=self.font, fill=255)
+#				display_string = "Press 'X' to confirm"
+#				text_width = self.draw.textsize(display_string, font=self.font)[0]
+#				self.draw.text((self.width / 2 - text_width / 2, top + offset + 9), display_string, font=self.font, fill=255)
+#				display_string = "Press any button or"
+#				text_width = self.draw.textsize(display_string, font=self.font)[0]
+#				self.draw.text((self.width / 2 - text_width / 2, top + offset + 18), display_string, font=self.font, fill=255)
+#				display_string = "wait 10 sec to escape"
+#				text_width = self.draw.textsize(display_string, font=self.font)[0]
+#				self.draw.text((self.width / 2 - text_width / 2, top + offset + 27), display_string, font=self.font, fill=255)
+#			except Exception as ex:
+#				self.log_error(ex)
+#
+#
+#	def update_ui_system(self):
+#		"""
+#		Update three-fourths of the screen with system stats collected by the timed collector
+#		"""
+#
+#		if self._display_init:
+#			top = (self._colored_strip_height) * int(self._progress_on_top)
+#			bottom = self.height - (self._colored_strip_height * int(not self._progress_on_top))
+#			left = 0
+#			offset = self._area_offset * int(self._progress_on_top)
+#
+#			# Draw a black filled box to clear the image.
+#			self.draw.rectangle((0, top, self.width, bottom), fill=0)
+#
+#			try:
+#				mem = self._system_stats['memory']
+#				disk = self._system_stats['disk']
+#
+#				# Center IP
+#				ip = self._system_stats['ip']
+#				tWidth, tHeight = self.draw.textsize(ip)
+#				self.draw.text((left + ((self.width - tWidth) / 2), top + offset + 0), ip, font=self.font, fill=255)
+#
+#				# System Stats
+#				self.draw.text((left, top + offset + 9), "L: %s, %s, %s" % self._system_stats['load'], font=self.font, fill=255)
+#				self.draw.text((left, top + offset + 18), "M: %s/%s MB %s%%" % (int(mem.used/1048576), int(mem.total/1048576), mem.percent), font=self.font, fill=255)
+#				self.draw.text((left, top + offset + 27), "D: %s/%s GB %s%%" % (int(disk.used/1073741824), int((disk.used+disk.total)/1073741824), int(10000*disk.used/(disk.used+disk.free))/100), font=self.font, fill=255)
+#			except:
+#				self.draw.text((left, top + offset + 9), "Gathering System Stats", font=self.font, fill=255)
+#
+#	def update_ui_printer(self):
+#		"""
+#		Update three-fourths of the screen with stats about the printer, such as temperatures
+#		"""
+#
+#		if self._display_init:
+#			top = (self._colored_strip_height) * int(self._progress_on_top)
+#			bottom = self.height - (self._colored_strip_height * int(not self._progress_on_top))
+#			left = 0
+#			offset = self._area_offset * int(self._progress_on_top)
+#
+#			try:
+#				self.draw.rectangle((0, top, self.width, bottom), fill=0)
+#				self.draw.text((left, top + offset + 0), "Printer Temperatures", font=self.font, fill=255)
+#
+#				if self._printer.get_current_connection()[0] == "Closed":
+#					self.draw.text((left, top + offset + 9), "Head: no printer", font=self.font, fill=255)
+#					self.draw.text((left, top + offset + 18), " Bed: no printer", font=self.font, fill=255)
+#				else:
+#					temperatures = self._printer.get_current_temperatures()
+#					tool = temperatures['tool0'] or None
+#					bed = temperatures['bed'] or None
+#
+#					self.draw.text((left, top + offset + 9), "Head: %s / %s\xb0C" % (tool['actual'], tool['target']), font=self.font, fill=255)
+#					self.draw.text((left, top + offset + 18), " Bed: %s / %s\xb0C" % (bed['actual'], bed['target']), font=self.font, fill=255)
+#			except Exception as ex:
+#				self.log_error(ex)
+#
+#	def update_ui_print(self, current_data):
+#		"""
+#		Update three-fourths of the screen with information about the current ongoing print
+#		"""
+#
+#		if self._display_init:
+#			top = (self._colored_strip_height) * int(self._progress_on_top)
+#			bottom = self.height - (self._colored_strip_height * int(not self._progress_on_top))
+#			left = 0
+#			offset = self._area_offset * int(self._progress_on_top)
+#
+#			try:
+#				self.draw.rectangle((0, top, self.width, bottom), fill=0)
+#				self.draw.text((left, top + offset + 0), "State: %s" % (self._printer.get_state_string()), font=self.font, fill=255)
+#
+#				if current_data['job']['file']['name']:
+#					file_name = current_data['job']['file']['name']
+#					self.draw.text((left, top + offset + 9), "File: %s" % (file_name), font=self.font, fill=255)
+#
+#					print_time = self._get_time_from_seconds(current_data['progress']['printTime'] or 0)
+#					self.draw.text((left, top + offset + 18), "Time: %s" % (print_time), font=self.font, fill=255)
+#
+#					filament = current_data['job']['filament']['tool0'] if "tool0" in current_data['job']['filament'] else current_data['job']['filament']
+#					filament_length = self.float_count_formatter((filament['length'] or 0) / 1000, 3)
+#					filament_mass = self.float_count_formatter(filament['volume'] or 0, 3)
+#					self.draw.text((left, top + offset + 27), "Filament: %sm/%scm3" % (filament_length, filament_mass), font=self.font, fill=255)
+#
+#					# Display height if information available from DisplayLayerProgress plugin
+#					height = "{:>5.1f}/{:>5.1f}".format(float(self._displaylayerprogress_current_height), float(self._displaylayerprogress_total_height))
+#					layer = "{:>4d}/{:>4d}".format(self._displaylayerprogress_current_layer, self._displaylayerprogress_total_layer)
+#					height_text = ""
+#					if self._displaylayerprogress_current_height != -1.0 and self._displaylayerprogress_current_layer != -1:
+#						height_text = layer + ";" + height
+#					elif self._displaylayerprogress_current_layer != -1:
+#						height_text = layer
+#					elif self._displaylayerprogress_current_height != -1.0:
+#						height_text = height
+#					self.draw.text((left, top + offset + 36), height_text, font=self.font, fill=255)
+#				else:
+#					self.draw.text((left, top + offset + 18), "Waiting for file...", font=self.font, fill=255)
+#			except Exception as ex:
+#				self.log_error(ex)
+#
+#	def update_ui_bottom(self, current_data):
+#		"""
+#		Update one-fourths of the screen with persistent information about the current print
+#		"""
+#
+#		if self._display_init:
+#			top = (self.height - self._colored_strip_height) * int(not self._progress_on_top)
+#			bottom = self.height - ((self.height - self._colored_strip_height) * int(self._progress_on_top))
+#			left = 0
+#
+#			try:
+#				# Clear area
+#				self.draw.rectangle((0, top, self.width, bottom), fill=0)
+#				display_string = ""
+#				if self._printer.get_current_connection()[0] == "Closed":
+#					# Printer isn't connected
+#					display_string = "Printer Not Connected"
+#				elif current_data['state']['flags']['paused'] or current_data['state']['flags']['pausing']:
+#					# Printer paused
+#					display_string = "Paused"
+#				elif current_data['state']['flags']['cancelling']:
+#					# Printer paused
+#					display_string = "Cancelling"
+#				elif current_data['state']['flags']['ready'] and (current_data['progress']['completion'] or 0) < 100:
+#					# Printer connected, not printing
+#					if current_data['job']['file']['name']:
+#						display_string = "Ready to Start"
+#					else:
+#						display_string = "Waiting For Job"
+#
+#				if display_string:
+#					text_width = self.draw.textsize(display_string, font=self.font)[0]
+#					self.draw.text((self.width / 2 - text_width / 2, top + 4), display_string, font=self.font, fill=255)
+#
+#				else:
+#					percentage = int(current_data['progress']['completion'] or 0)
+#					# Calculate progress from time
+#					if current_data['progress']['printTime'] and self._timebased_progress:
+#						percentage = int((current_data['progress']['printTime'] or 0) / ((current_data['progress']['printTime'] or 0) + current_data['progress']['printTimeLeft']) * 100)
+#					time_left = current_data['progress']['printTimeLeft'] or 0
+#
+#					# Progress bar
+#					self.draw.rectangle((0, top + 0, self.width - 1, top + 5), fill=0, outline=255, width=1)
+#					bar_width = int((self.width - 5) * percentage / 100)
+#					self.draw.rectangle((2, top + 2, bar_width, top + 3), fill=255, outline=255, width=1)
+#
+#					# Percentage and ETA
+#					self.draw.text((0, top + 5), "%s%%" % (percentage), font=self.font, fill=255)
+#					eta = time.strftime(self._eta_strftime, time.localtime(time.time() + time_left))
+#					eta_width = self.draw.textsize(eta, font=self.font)[0]
+#					self.draw.text((self.width - eta_width, top + 5), eta, font=self.font, fill=255)
+#			except Exception as ex:
+#				self.log_error(ex)
+#
+#	# Taken from tpmullan/OctoPrint-DetailedProgress
+#	def _get_time_from_seconds(self, seconds):
+#		hours = 0
+#		minutes = 0
+#
+#		if seconds >= 3600:
+#			hours = int(seconds / 3600)
+#			seconds = seconds % 3600
+#
+#		if seconds >= 60:
+#			minutes = int(seconds / 60)
+#			seconds = seconds % 60
+#
+#		return self._etl_format.format(**locals())
+#
+#	def float_count_formatter(self, number, max_chars):
+#		"""
+#		Show decimals up to a max number of characters, then flips over and rounds to integer
+#		"""
+#
+#		int_part = "%i" % round(number)
+#		if len(int_part) >= max_chars - 1:
+#			return int_part
+#		elif len("%f" % number) <= max_chars:
+#			return "%f" % number
+#		else:
+#			return "{num:0.{width}f}".format(num=number, width=len(int_part) - 1)
 
 	def log_error(self, ex):
 		"""

--- a/octoprint_display_panel/__init__.py
+++ b/octoprint_display_panel/__init__.py
@@ -569,9 +569,10 @@ class Display_panelPlugin(octoprint.plugin.StartupPlugin,
 	def setup_screens(self):
 		"""Create the top level screen.
 		"""
-		self.top_screen = screens.MicroPanelScreenTop(self.width,
-							      self.height)
-		
+		self.top_screen = screens.MicroPanelScreenTop(
+			self.width, self.height,
+			self._printer, self._settings
+		)
 		
 	def handle_button_press(self, label):
 		"""

--- a/octoprint_display_panel/__init__.py
+++ b/octoprint_display_panel/__init__.py
@@ -22,40 +22,6 @@ import RPi.GPIO as GPIO
 
 from . import screens
 
-## REFACTORING SCOPES
-##   Changes to the following are scoped to a specific branch, and should
-##   not be modified by another branch. Conflicting changes should be done
-##   in the top-level refactor branch.
-##
-## refactor/virtual-panel
-##   - setup_display(), clear_display()
-##   - setup_gpio(), configure_gpio(), configure_single_gpio(), clean_gpio()
-##   - handle_gpio_event()
-##   - initialize(), get_settings_defaults(), on_settings_save()
-##   - bcm2board()
-##   - start_display_timer(), stop_display_timer(), trigger_display_timeout()
-## refactor/modular-screens
-##   - handle_button_press()
-##   - next_mode(), try_cancel(), clear_cancel(), try_play(), try_pause()
-##   - update_ui() and all other update_ui_***()
-##   - _screen_mode, ScreenModes
-##   - on_event(), on_print_progress(), on_slicing_progress()
-##   - start_system_timer(), check_system_stats()
-##   - set_printer_state()
-
-## COMMON INTERFACE
-##   The following shall be stable from the top-level refactor branch.
-##
-## Display_panelPlugin.disp
-##   - disp.width, disp.height
-##   - disp.fill(n)
-##   - disp.show()
-##   - disp.poweroff(), disp.poweron()
-##   - disp.image(img)
-## Display_panelPlugin.handle_button_press(label)
-## Display_panelPlugin.update_ui()
-## Display_panelPlugin.start_system_timer()
-## Display_panelPlugin.start_display_timer(reconfigure)
 
 class ScreenModes(Enum):
 	PRINT = 1

--- a/octoprint_display_panel/screens/__init__.py
+++ b/octoprint_display_panel/screens/__init__.py
@@ -6,34 +6,56 @@ class MicroPanelScreenTop(base.MicroPanelScreenBase):
     def __init__(self, width, height):
         super().__init__(width, height)
 
+        self.status_bar_height = 16
+        if status_bar_on_top:
+            self.status_bar_top = 0
+        else:
+            self.status_bar_top = height - self.status_bar_height
+        self.status_bar_screen = printer.PrinterStatusBarScreen(
+            width, self.status_bar_height)
+
+        subscreen_height = height - self.status_bar_height
         self.screens = [
-            system.SystemInfoScreen,
-            printer.PrinterInfoScreen,
-            printer.PrintStatusScreen,
+            system.SystemInfoScreen(width, subscreen_height),
+            printer.PrinterInfoScreen(width, subscreen_height),
+            printer.PrintStatusScreen(width, subscreen_height),
         ]
         self.current_screen = 0
-        self.set_subscreen(self.screens[0])
+        self.set_subscreen(self.screens[self.current_screen])
+
+    def set_subscreen(self, screen):
+        size = (self.width, self.height - self.status_bar_height)
+        super().set_subscreen(screen, size=size)
+
+    @property
+    def image(self):
+        if self.status_bar_top == 0:
+            main_top = self.status_bar_height
+        else:
+            main_top = 0
+            
+        c = self.get_canvas()
+        main_image = super().image
+        c.image.paste(main_image, (0, main_top))
+        if main_image.size[1] < self.height:
+            c.image.paste(self.status_bar_screen.image, (0, status_bar_top))
+        return c.image
 
     def handle_button(self, label):
         if label == 'menu':
             self.current_screen += 1
             self.current_screen %= len(self.screens)
-            self.set_subscreen(self.screens[0])
+            self.set_subscreen(self.screens[self.current_screen])
             return {'DRAW'}
-        else:
-            return MicroPanelScreenBase.handle_button(self, label)
-        
-#    def draw(self):
-#        return self.screens[self.current_screen].draw()
-#
-#    def wants_event(self, event):
-#        return True
-#    
-#    def handle_event(self, event, payload):
-#        retval = {}
-#        for screen in self.screens:
-#            if screen.wants_event(event):
-#                v = screen.handle_event(event, payload)
-#                if v is not None:
-#                    retval.add(v)
-#        return retval
+
+        if label == 'play':
+            # connect the printer, start the job, etc.
+            return {'DRAW'}
+
+        if label == 'pause':
+            # pause the job
+            return {'DRAW'}
+
+        if label == 'cancel' and job_is_running:
+            self.set_subscreen(printer.JobCancelScreen)
+            return {'DRAW'}

--- a/octoprint_display_panel/screens/__init__.py
+++ b/octoprint_display_panel/screens/__init__.py
@@ -1,0 +1,39 @@
+
+
+from . import base, system, printer
+
+class MicroPanelScreenTop(base.MicroPanelScreenBase):
+    def __init__(self, width, height):
+        super().__init__(width, height)
+
+        self.screens = [
+            system.SystemInfoScreen,
+            printer.PrinterInfoScreen,
+            printer.PrintStatusScreen,
+        ]
+        self.current_screen = 0
+        self.set_subscreen(self.screens[0])
+
+    def handle_button(self, label):
+        if label == 'menu':
+            self.current_screen += 1
+            self.current_screen %= len(self.screens)
+            self.set_subscreen(self.screens[0])
+            return {'DRAW'}
+        else:
+            return MicroPanelScreenBase.handle_button(self, label)
+        
+#    def draw(self):
+#        return self.screens[self.current_screen].draw()
+#
+#    def wants_event(self, event):
+#        return True
+#    
+#    def handle_event(self, event, payload):
+#        retval = {}
+#        for screen in self.screens:
+#            if screen.wants_event(event):
+#                v = screen.handle_event(event, payload)
+#                if v is not None:
+#                    retval.add(v)
+#        return retval

--- a/octoprint_display_panel/screens/__init__.py
+++ b/octoprint_display_panel/screens/__init__.py
@@ -3,8 +3,10 @@ from . import base, system, printer
 
 
 class MicroPanelScreenTop(base.MicroPanelScreenBase):
-    def __init__(self, width, height):
+    def __init__(self, width, height, _printer, _settings):
         super().__init__(width, height)
+        self._printer = printer.PrinterHelper(_printer)
+        self._settings = _settings
 
         self.status_bar_height = 16
         if status_bar_on_top:
@@ -12,13 +14,15 @@ class MicroPanelScreenTop(base.MicroPanelScreenBase):
         else:
             self.status_bar_top = height - self.status_bar_height
         self.status_bar_screen = printer.PrinterStatusBarScreen(
-            width, self.status_bar_height)
+            width, self.status_bar_height, self._printer, self._settings)
 
         self.subscreen_height = height - self.status_bar_height
         self.screens = {
             'system': system.SystemInfoScreen(width, self.subscreen_height),
-            'printer': printer.PrinterInfoScreen(width, self.subscreen_height),
-            'print': printer.PrintStatusScreen(width, self.subscreen_height),
+            'printer': printer.PrinterInfoScreen(width, self.subscreen_height,
+                                                 self._printer),
+            'print': printer.PrintStatusScreen(width, self.subscreen_height,
+                                               self._printer),
         }
         self.current_screen = 'system'
         self.set_subscreen(self.current_screen)

--- a/octoprint_display_panel/screens/__init__.py
+++ b/octoprint_display_panel/screens/__init__.py
@@ -1,13 +1,51 @@
+"""Top-level implementation of Micro Panel screens.
+
+Each screen consists of a set of data that can be shown to the user,
+can be updated through events from OctoPrint's main event system, and
+can react to user interaction through button presses. Screens must
+implement the `draw()` method at a minimum, but can implement
+`handle_button()` and/or `handle_event()` as well. Screens may also
+designate another screen instance as a "subscreen", which will
+temporarily replace the contents of the screen. For more details about
+implementing screens, see base.py.
+
+"""
 from octoprint.events import Events
 
 from . import base, system, printer
 
 
+class MessageScreen(base.MicroPanelScreenBase):
+    """A trivial implementation of a screen, for displaying a simple message.
+
+    This screen is used by the main __init__.py as a fallback display
+    in case the main set of screens cannot be initialized.
+
+    """
+    def __init__(self, width, height, message):
+        super().__init__(width, height)
+        self.message = message
+
+    def draw(self):
+        c = self.get_canvas()
+        c.text_centered(0, self.message)
+        return c.image
+
+
 class MicroPanelScreenTop(base.MicroPanelScreenBase):
+    """The top-level screen for the Micro Panel.
+
+    This class uses extensive overrides of the base class in order to
+    implement its core behavior, which is to support a small status
+    bar screen as well as a rotating subscreen. Most typical screens
+    will not need this level of complexity.
+
+    """
     def __init__(self, width, height, _printer, _settings):
         self._printer = printer.PrinterHelper(_printer)
         self._settings = _settings
 
+        # Define the status bar screen, which is typically displayed.
         self.status_bar_height = 16
         if self._settings.get_boolean(["progress_on_top"], merged=True):
             self.status_bar_top = 0
@@ -16,6 +54,9 @@ class MicroPanelScreenTop(base.MicroPanelScreenBase):
         self.status_bar_screen = printer.PrinterStatusBarScreen(
             width, self.status_bar_height, self._printer, self._settings)
 
+        # Define the main set of subscreens. These screens will be
+        # rotated through via the 'mode' button in the order they are
+        # listed below.
         self.subscreen_height = height - self.status_bar_height
         self.screens = {
             'system': system.SystemInfoScreen(width, self.subscreen_height),
@@ -43,12 +84,16 @@ class MicroPanelScreenTop(base.MicroPanelScreenBase):
             self.__subscreen = s
         
     def set_subscreen(self, screen):
+        """Set the desired subscreen, via string or subscreen instance.
+        """
         if isinstance(screen, str):
             self.current_screen = screen
             screen = self.screens[screen]
         super().set_subscreen(screen)
 
     def next_subscreen(self):
+        """Rotate to the next subscreen in the set of screens.
+        """
         screen_list = list(self.screens.keys())
         i = screen_list.index(self.current_screen)
         i = (i + 1) % len(screen_list)
@@ -56,6 +101,8 @@ class MicroPanelScreenTop(base.MicroPanelScreenBase):
         
     @property
     def image(self):
+        """Render this screen by combining the status bar and the subscreen.
+        """
         if self.status_bar_top == 0:
             main_top = self.status_bar_height
         else:
@@ -70,12 +117,14 @@ class MicroPanelScreenTop(base.MicroPanelScreenBase):
         return c.image
 
     def handle_button(self, label):
+        """Take action on a button press, if not handled by the subscreen.
+        """
         if label == 'mode':
             self.next_subscreen()
             return {'DRAW'}
 
         if label == 'play':
-            if self._printer.is_disconnected:
+            if self._printer.is_disconnected():
                 if self._printer:
                     self._printer.connect()
                 return {'DRAW'}
@@ -100,7 +149,7 @@ class MicroPanelScreenTop(base.MicroPanelScreenBase):
             return {'DRAW'}
 
         if label == 'cancel':
-            if self._printer.is_disconnected:
+            if self._printer.is_disconnected():
                 return {'IGNORE'}
 
             if (not self._printer.is_printing()
@@ -108,14 +157,22 @@ class MicroPanelScreenTop(base.MicroPanelScreenBase):
                 return {'IGNORE'}
             
             self.set_subscreen(
-                printer.JobCancelScreen(self.width, self.subscreen_height))
+                printer.JobCancelScreen(self.width, self.subscreen_height,
+                                        self._printer))
             return {'DRAW'}
 
+    # The list of events to be processed by this screen
     EVENTS = [
         Events.DISCONNECTED, Events.PRINT_STARTED
     ]
 
     def handle_event(self, event, payload):
+        """Handle events for this screen.
+        """
+        # We only need to process events here that affect which
+        # subscreen we are currently displaying. Events affecting the
+        # display of subscreens will be automatically passed to the
+        # subscreen.
         if event == Events.DISCONNECTED:
             self.set_subscreen('system')
         elif event == Events.PRINT_STARTED:
@@ -124,10 +181,23 @@ class MicroPanelScreenTop(base.MicroPanelScreenBase):
         return {'DRAW'}
 
     def process_event(self, event, payload):
+        """Distribute all incoming events.
+
+        This method is overridden in order to pass events to the
+        status bar as well as to the print status screen when it is
+        not being displayed.
+
+        """
         r = set()
         # also pass the event to the status bar screen
         if self.status_bar_screen.wants_event(event):
             r.update(self.status_bar_screen.process_event(event, payload))
 
+        # and pass it to the print status screen, if it isn't being displayed
+        if self.screens['print'].wants_event(event):
+            if self.subscreen != self.screens['print']:
+                # don't propagate its response, because it's not on screen
+                self.screens['print'].process_event(event, payload)
+            
         r.update(super().process_event(event, payload))
         return r

--- a/octoprint_display_panel/screens/__init__.py
+++ b/octoprint_display_panel/screens/__init__.py
@@ -1,6 +1,6 @@
 
-
 from . import base, system, printer
+
 
 class MicroPanelScreenTop(base.MicroPanelScreenBase):
     def __init__(self, width, height):
@@ -14,19 +14,42 @@ class MicroPanelScreenTop(base.MicroPanelScreenBase):
         self.status_bar_screen = printer.PrinterStatusBarScreen(
             width, self.status_bar_height)
 
-        subscreen_height = height - self.status_bar_height
-        self.screens = [
-            system.SystemInfoScreen(width, subscreen_height),
-            printer.PrinterInfoScreen(width, subscreen_height),
-            printer.PrintStatusScreen(width, subscreen_height),
-        ]
-        self.current_screen = 0
-        self.set_subscreen(self.screens[self.current_screen])
+        self.subscreen_height = height - self.status_bar_height
+        self.screens = {
+            'system': system.SystemInfoScreen(width, self.subscreen_height),
+            'printer': printer.PrinterInfoScreen(width, self.subscreen_height),
+            'print': printer.PrintStatusScreen(width, self.subscreen_height),
+        }
+        self.current_screen = 'system'
+        self.set_subscreen(self.current_screen)
 
+    # This use of a property setter overrides the base behavior of
+    # subscreens, so that if the subscreen is being set to None, it
+    # instead gets set to the value of self.current_screen.
+    @property
+    def subscreen(self):
+        return self.__subscreen
+
+    @subscreen.setter
+    def subscreen(self, s):
+        if s is None:
+            self.set_subscreen(self.current_screen)
+        else:
+            self.__subscreen = s
+        
     def set_subscreen(self, screen):
+        if isinstance(screen, str):
+            screen = self.screens[screen]
+            self.current_screen = screen
         size = (self.width, self.height - self.status_bar_height)
         super().set_subscreen(screen, size=size)
 
+    def next_subscreen(self):
+        screen_list = list(self.screens.keys())
+        i = screen_list.index(self.current_screen)
+        i = (i + 1) % len(screen_list)
+        self.set_subscreen(screen_list[i])
+        
     @property
     def image(self):
         if self.status_bar_top == 0:
@@ -43,19 +66,54 @@ class MicroPanelScreenTop(base.MicroPanelScreenBase):
 
     def handle_button(self, label):
         if label == 'menu':
-            self.current_screen += 1
-            self.current_screen %= len(self.screens)
-            self.set_subscreen(self.screens[self.current_screen])
+            self.next_subscreen()
             return {'DRAW'}
 
         if label == 'play':
-            # connect the printer, start the job, etc.
-            return {'DRAW'}
+            if printer.PRINTER.is_disconnected:
+                if printer.PRINTER:
+                    printer.PRINTER.connect()
+                return {'DRAW'}
 
+            if (printer.PRINTER.flags['ready']
+                and (printer.PRINTER.progress['completion'] or 0) == 0
+                and printer.PRINTER.job['file']['name']):
+                printer.PRINTER.start_print()
+                return {'DRAW'}
+
+            if not printer.PRINTER.is_paused():
+                return {'IGNORE'}
+
+            printer.PRINTER.resume_print()
+            return {'DRAW'}
+            
         if label == 'pause':
-            # pause the job
+            if not printer.PRINTER or not printer.PRINTER.is_printing():
+                return {'IGNORE'}
+
+            printer.PRINTER.pause_print()
             return {'DRAW'}
 
-        if label == 'cancel' and job_is_running:
-            self.set_subscreen(printer.JobCancelScreen)
+        if label == 'cancel':
+            if printer.PRINTER.is_disconnected:
+                return {'IGNORE'}
+
+            if (not printer.PRINTER.is_printing()
+                and not printer.PRINTER.is_paused()):
+                return {'IGNORE'}
+            
+            self.set_subscreen(
+                printer.JobCancelScreen(self.width, self.subscreen_height))
             return {'DRAW'}
+
+    EVENTS = [
+        Events.DISCONNECTED, Events.PRINT_STARTED
+    ]
+
+    def handle_event(self, event, payload):
+        if event == Events.DISCONNECTED:
+            self.set_subscreen('system')
+        elif event == Events.PRINT_STARTED:
+            self.set_subscreen('print')
+
+        return {'DRAW'}

--- a/octoprint_display_panel/screens/base.py
+++ b/octoprint_display_panel/screens/base.py
@@ -1,30 +1,132 @@
+"""Base class of all Micro Panel screens.
+
+The MicroPanelScreenBase class here should be subclassed to implement
+your desired screen. At a minimum, you should implement the `draw()`
+method:
+
+  class HelloWorldScreen(base.MicroPanelScreenBase):
+      def draw(self):
+          c = self.get_canvas()
+          c.text_centered(0, "Hello World!")
+          return c.image
+
+Note the use of `get_canvas()`, which returns an instance of
+MicroPanelCanvas which can make certain routine drawing operations
+(primarily text) easier.
+
+Screens are drawn whenever the plugin core determines they need to be
+drawn; typically, no less frequently than every 5 seconds, but can be
+arbitrarily often. If your screen's data changes based on printer
+events, for example, you should implement the `handle_event()` method
+and the `EVENTS` list, and return a set including the string 'DRAW' to
+signal that your screen is ready to be redrawn.
+
+  class EventScreen(base.MicroPanelScreenBase):
+      def __init__(self, *args, **kwargs):
+          super().__init__(*args, **kwargs)
+          self.last_event = "none"
+
+      def draw(self):
+          c = self.get_canvas()
+          c.text((0,0), "Last Event:")
+          c.text((20,10), self.last_event)
+          return c.image
+
+      EVENTS = [Events.DISCONNECTED, Events.CONNECTING, Events.CONNECTED]
+
+      def handle_event(self, event, payload):
+          self.last_event = event
+          return {'DRAW'}
+
+Similarly, if your screen needs to react to a button press, you should
+implement the `handle_button()` method.
+
+    class ButtonScreen(base.MicroPanelScreenBase):
+      def __init__(self, *args, **kwargs):
+          super().__init__(*args, **kwargs)
+          self.last_button = "none"
+
+      def draw(self):
+          c = self.get_canvas()
+          c.text((0,0), "Last Button:")
+          c.text((20,10), self.last_button)
+          return c.image
+
+      def handle_button(self, label):
+          self.last_button = label
+          return {'DRAW'}
+
+If `handle_button()` does not return anything or returns an empty set,
+the button will be handled by the parent screen. If you want your
+subscreen to not react to a certain button label, return the value
+{'IGNORE'}.
+
+You can also set a subscreen using the `set_subscreen()`
+method. Subscreens will stay active until they return the value
+{'BACK'} from either `handle_button()` or `handle_event()`.
+
+"""
 
 from PIL import Image, ImageDraw, ImageFont
 
 
 DEFAULT_FONT = ImageFont.load_default()
+DEFAULT_FONT_LINE_HEIGHT = 9
 
 
 class MicroPanelCanvas:
+    """Helper class for providing a pre-initialized drawing surface for screens.
+    
+    This class provides a bit of assistance with drawing text
+    (particularly centered or right-aligned). It also proxies all
+    other methods available from the ImageDraw.Draw class. Drawn image
+    data can be retrieved by the `image` instance variable.
+
+    """
     def __init__(self, width, height):
         self.width, self.height = width, height
         self.image = Image.new("1", (self.width, self.height))
         self.draw = ImageDraw.Draw(self.image)
 
     def fill(self, color):
+        """Fill the entire canvas with the specified color.
+        
+        Typical colors: 0=black, 255=white
+
+        """
         self.rectangle((0, 0, self.width, self.height), fill=color)
 
     def text(self, point, message, **kwargs):
+        """Draw text at a point on the canvas.
+
+        The point is a 2-tuple (x, y). It defaults to white color and
+        the default font, but these and all other settings from
+        `draw.text()` can be overridden with kwargs.
+
+        """
         kwargs.setdefault('font', DEFAULT_FONT)
         kwargs.setdefault('fill', 255)
         self.draw.text(point, message, **kwargs)
 
     def text_right(self, y, message, **kwargs):
+        """Draw text, right aligned, at the given position on the canvas.
+        
+        The text will be aligned to the far right edge of the canvas,
+        with the top edge at the provided `y` position. If multiple
+        lines are present in the message (newline separated), each
+        line will be individually right aligned.
+
+        """
         kwargs.setdefault('font', DEFAULT_FONT)
         text_size = self.textsize(message, font=kwargs['font'])
         if '\n' in message:
             lines = message.rstrip('\n').split('\n')
-            line_height = text_size[1] / len(lines)
+            if kwargs['font'] == DEFAULT_FONT:
+                line_height = DEFAULT_FONT_LINE_HEIGHT
+            elif 'line_height' in kwargs:
+                line_height = kwargs['line_height']
+            else:
+                line_height = text_size[1] / len(lines)
             for i, line in enumerate(message.rstrip('\n').split('\n')):
                 self.text_right(y + (i * line_height), line, **kwargs)
         else:
@@ -32,11 +134,24 @@ class MicroPanelCanvas:
             self.text((x, y), message, **kwargs)
         
     def text_centered(self, y, message, **kwargs):
+        """Draw text, centered, at the given position on the canvas.
+
+        The text will be centered on the canvas, with the top edge at
+        the provided `y` position. If multiple lines are present in
+        the message (newline separated), each line will be
+        individually centered.
+
+        """
         kwargs.setdefault('font', DEFAULT_FONT)
         text_size = self.textsize(message, font=kwargs['font'])
         if '\n' in message:
             lines = message.rstrip('\n').split('\n')
-            line_height = text_size[1] / len(lines)
+            if kwargs['font'] == DEFAULT_FONT:
+                line_height = DEFAULT_FONT_LINE_HEIGHT
+            elif 'line_height' in kwargs:
+                line_height = kwargs['line_height']
+            else:
+                line_height = text_size[1] / len(lines)
             for i, line in enumerate(message.rstrip('\n').split('\n')):
                 self.text_centered(y + (i * line_height), line, **kwargs)
         else:
@@ -44,22 +159,29 @@ class MicroPanelCanvas:
             self.text((x, y), message, **kwargs)
         
     def __getattr__(self, key):
+        """Proxy any other attributes (methods) to the canvas draw instance.
+        """
         return getattr(self.draw, key)
 
 
 class MicroPanelScreenBase:
     def __init__(self, width, height):
+        """Initialize the base screen.
+        
+        Subclasses which override __init__() should call this function
+        to ensure that the width and height are always set.
+
+        """
         self.width = width
         self.height = height
         self.subscreen = None
 
     def draw(self):
         """Create an image representing the current state of this screen.
+
+        This method should be overridden in a subclass.
+
         """
-        # TODO: add separate functions for drawing the main body
-        #       full-screen, for drawing the body accounting for a
-        #       header, and for drawing the header. The top level
-        #       plugin will decide which functions it wants to call.
         pass
 
     def handle_button(self, label):
@@ -103,6 +225,8 @@ class MicroPanelScreenBase:
         
     @property
     def image(self):
+        """Draw the current subscreen, or screen, and return its image.
+        """
         if self.subscreen is not None:
             img = self.subscreen.image
             if img:
@@ -110,11 +234,20 @@ class MicroPanelScreenBase:
         return self.draw()
         
     def process_event(self, event, payload):
+        """Process an incoming event for this screen and its subscreen.
+        
+        This function is typically called by the plugin core and
+        should not normally be overridden in a subclass. Subclasses
+        should instead implement `handle_event()` and include the
+        desired event in the `EVENTS` list.
+
+        """
         r = set()
         if self.subscreen is not None:
             if self.subscreen.wants_event(event):
                 r.update(self.subscreen.process_event(event, payload))
 
+        # The subscreen wants to cancel itself
         if 'BACK' in r:
             self.subscreen = None
             r.remove('BACK')
@@ -126,6 +259,13 @@ class MicroPanelScreenBase:
         return r
 
     def process_button(self, label):
+        """Process an incoming button press for this screen or its subscreen.
+
+        This function is typically called by the plugin core and
+        should not normally be overridden in a subclass. Subclasses
+        should instead implement `handle_button()`.
+
+        """
         r = set()
         if self.subscreen is not None:
             r.update(self.subscreen.process_button(label))
@@ -135,9 +275,13 @@ class MicroPanelScreenBase:
             r.remove('BACK')
             r.add('DRAW')
         elif not r:
+            # We only handle the button press ourselves if the
+            # subscreen didn't handle it (by returning a value)
             r.update(self.handle_button(label) or set())
             
         return r
 
     def get_canvas(self):
+        """Create a new canvas instance for drawing a screen.
+        """
         return MicroPanelCanvas(self.width, self.height)

--- a/octoprint_display_panel/screens/base.py
+++ b/octoprint_display_panel/screens/base.py
@@ -1,0 +1,51 @@
+
+
+class MicroPanelScreenBase:
+    def __init__(self, width, height):
+        self.width = width
+        self.height = height
+        self._subscreen = None
+        
+    def draw(self):
+        """Create an image representing the current state of this screen.
+        """
+        # TODO: add separate functions for drawing the main body
+        #       full-screen, for drawing the body accounting for a
+        #       header, and for drawing the header. The top level
+        #       plugin will decide which functions it wants to call.
+        
+        # TODO: If a subscreen does not return a value for a drawing
+        #       function, the parent screen should return its value.
+        pass
+
+    def handle_button(self, label):
+        """Take action on the given button press.
+        """
+        # TODO: return value should be a set with flags in it, such as
+        #       'BACK' (the user or event wants to return up to the
+        #       parent screen) or 'DRAW' (the event requires a screen
+        #       refresh)
+        pass
+
+    EVENTS = []
+    
+    def wants_event(self, event):
+        """True if this event is in the list of events processed by this screen.
+        """
+        return event in self.EVENTS
+    
+    def handle_event(self, event, payload):
+        """Take action on the given OctoPrint event.
+        """
+        pass
+
+    def set_subscreen(self, screen, *args, **kwargs):
+        """Set the given screen as an active subscreen of this one.
+
+        All draw and event handling will be processed by the subscreen
+        until either something removes the subscreen here or the event
+        or button handlers return a value 'BACK'.
+
+        """
+        self.subscreen = screen(self.width, self.height, *args, **kwargs)
+        

--- a/octoprint_display_panel/screens/base.py
+++ b/octoprint_display_panel/screens/base.py
@@ -1,11 +1,46 @@
 
+from PIL import Image, ImageDraw, ImageFont
+
+
+DEFAULT_FONT = ImageFont.load_default()
+
+
+class MicroPanelCanvas:
+    def __init__(self, width, height):
+        self.width, self.height = width, height
+        self.image = Image.new("1", (self.width, self.height))
+        self.draw = ImageDraw.Draw(self.image)
+
+    def fill(self, color):
+        self.rectangle((0, 0, self.width, self.height), fill=color)
+
+    def text(self, point, message, **kwargs):
+        kwargs.setdefault('font', DEFAULT_FONT)
+        kwargs.setdefault('fill', 255)
+        self.text(point, message, **kwargs)
+        
+    def text_centered(self, y, message, **kwargs):
+        kwargs.setdefault('font', DEFAULT_FONT)
+        text_size = self.textsize(message, font=kwargs['font'])
+        if '\n' in message:
+            lines = message.rstrip('\n').split('\n')
+            line_height = text_size[1] / len(lines)
+            for i, line in enumerate(message.rstrip('\n').split('\n')):
+                self.text_centered(y + (i * line_height), line, **kwargs)
+        else:
+            x = (self.width / 2) - (text_width[0] / 2)
+            self.text((x, y), message, **kwargs)
+        
+    def __getattr__(self, key):
+        return getattr(self.draw, key)
+
 
 class MicroPanelScreenBase:
     def __init__(self, width, height):
         self.width = width
         self.height = height
-        self._subscreen = None
-        
+        self.subscreen = None
+
     def draw(self):
         """Create an image representing the current state of this screen.
         """
@@ -13,18 +48,16 @@ class MicroPanelScreenBase:
         #       full-screen, for drawing the body accounting for a
         #       header, and for drawing the header. The top level
         #       plugin will decide which functions it wants to call.
-        
-        # TODO: If a subscreen does not return a value for a drawing
-        #       function, the parent screen should return its value.
         pass
 
     def handle_button(self, label):
         """Take action on the given button press.
+
+        This function may return a set containing action flags:
+        - 'BACK': The current subscreen should be removed
+        - 'DRAW': The screen should be refreshed
+
         """
-        # TODO: return value should be a set with flags in it, such as
-        #       'BACK' (the user or event wants to return up to the
-        #       parent screen) or 'DRAW' (the event requires a screen
-        #       refresh)
         pass
 
     EVENTS = []
@@ -36,10 +69,15 @@ class MicroPanelScreenBase:
     
     def handle_event(self, event, payload):
         """Take action on the given OctoPrint event.
+
+        This function may return a set containing action flags:
+        - 'BACK': The current subscreen should be removed
+        - 'DRAW': The screen should be refreshed
+
         """
         pass
 
-    def set_subscreen(self, screen, *args, **kwargs):
+    def set_subscreen(self, screen):
         """Set the given screen as an active subscreen of this one.
 
         All draw and event handling will be processed by the subscreen
@@ -47,5 +85,39 @@ class MicroPanelScreenBase:
         or button handlers return a value 'BACK'.
 
         """
-        self.subscreen = screen(self.width, self.height, *args, **kwargs)
+        self.subscreen = screen
         
+    @property
+    def image(self):
+        if self.subscreen is not None:
+            img = self.subscreen.image
+            if img:
+                return img
+        return self.draw()
+        
+    def process_event(self, event, payload):
+        r = set()
+        if self.subscreen is not None:
+            if self.subscreen.wants_event(event):
+                r.update(self.subscreen.process_event(event, payload))
+            
+        if self.wants_event(event):
+            r.update(self.handle_event(event, payload) or set())
+
+        return r
+
+    def process_button(self, label):
+        r = set()
+        if self.subscreen is not None:
+            r.update(self.subscreen.process_button(label))
+
+        if 'BACK' in r:
+            self.subscreen = None
+            r.remove('BACK')
+        elif not r:
+            r.update(self.handle_button(label) or set())
+            
+        return r
+
+    def get_canvas(self):
+        return MicroPanelCanvas(self.width, self.height)

--- a/octoprint_display_panel/screens/base.py
+++ b/octoprint_display_panel/screens/base.py
@@ -17,7 +17,7 @@ class MicroPanelCanvas:
     def text(self, point, message, **kwargs):
         kwargs.setdefault('font', DEFAULT_FONT)
         kwargs.setdefault('fill', 255)
-        self.text(point, message, **kwargs)
+        self.draw.text(point, message, **kwargs)
 
     def text_right(self, y, message, **kwargs):
         kwargs.setdefault('font', DEFAULT_FONT)

--- a/octoprint_display_panel/screens/printer.py
+++ b/octoprint_display_panel/screens/printer.py
@@ -1,23 +1,73 @@
-
+import time
+import threading
+from octoprint.events import Events, eventManager
+from octoprint.util import monotonic_time
 
 from . import base
 
 
-# TODO: either fully implement this or think of some other way to get
-#       _printer from the main plugin up to this module
-#
-#class OctoPrintPrinterProxy:
-#    def __init__(self):
-#        self._printer = None
-#
-#    def __getattr__(self, key):
-#        if self._printer:
-#            return getattr(self._printer, key)
-#
-#    def set(self, printer):
-#        self._printer = printer
-#        
-#PRINTER = OctoPrintPrinterProxy()
+class OctoPrintPrinterProxy:
+    def __init__(self):
+        self._printer = None
+
+    def __bool__(self):
+        return self._printer is not None
+        
+    def __getattr__(self, key):
+        if self._printer:
+            return getattr(self._printer, key)
+
+    def set(self, printer):
+        self._printer = printer
+
+    # Helper methods
+
+    @property
+    def flags(self):
+        return self._printer.get_current_data()['state']['flags']
+
+    @property
+    def progress(self):
+        return self._printer.get_current_data()['progress']
+
+    @property
+    def job(self):
+        return self._printer.get_current_data()['job']
+
+    @property
+    def is_disconnected(self):
+        if self._printer is None:
+            return True
+        return self._printer.get_current_connection()[0] == 'Closed'
+        
+PRINTER = OctoPrintPrinterProxy()
+
+
+def get_time_from_seconds(seconds):
+    """Convert a number of seconds into a human readable duration.
+
+    Taken from tpmullan/OctoPrint-DetailedProgress
+    """
+    hours = 0
+    minutes = 0
+    if seconds >= 3600:
+        hours = seconds // 3600
+        seconds %= 3600
+    if seconds >= 60:
+        minutes = seconds // 60
+        seconds %= 60
+    
+    return f"{hours:02d}h {minutes:02d}m {seconds:02d}s"
+    
+
+def float_count_formatter(number, max_chars):
+    """Show decimals up to length max_chars, then rounds to integer
+    """
+
+    int_part = str(int(round(number)))
+    if len(int_part) >= max_chars - 1:
+        return int_part
+    return f"{number:0.{max_chars-len(int_part)-1}f}"
 
 
 class PrinterInfoScreen(base.MicroPanelScreenBase):
@@ -27,7 +77,7 @@ class PrinterInfoScreen(base.MicroPanelScreenBase):
         head_text = "no printer"
         bed_text = "no printer"
         
-        if PRINTER.get_current_connection()[0] != 'Closed':
+        if PRINTER and not PRINTER.is_disconnected()
             temperatures = PRINTER.get_current_temperatures()
             tool = temperatures['tool0']
             if tool:
@@ -45,35 +95,196 @@ class PrinterInfoScreen(base.MicroPanelScreenBase):
 
         return c.image
 
+    EVENTS = [
+        Events.DISCONNECTED, Events.CONNECTED, Events.CONNECTING,
+        Events.CONNECTIVITY_CHANGED, Events.DISCONNECTING,
+        Events.Z_CHANGE, Events.PRINTER_STATE_CHANGED
+    ]
+
+    def handle_event(self, event, payload):
+        return {'DRAW'}
+    
 
 class PrintStatusScreen(base.MicroPanelScreenBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.display_layer_progress = {
+            'current_layer': -1, 'total_layer': -1,
+            'current_height': -1.0, 'total_height': -1.0
+        }
+        
     def draw(self):
         c = self.get_canvas()
+        if not PRINTER:
+            c.text((0, 0), f"State: unavailable")
+            return c.image
+            
         c.text((0, 0), f"State: {PRINTER.get_state_string()}")
 
         current_data = PRINTER.get_current_data()
-        if current_data['job']['file']['name']:
+        if PRINTER.job['file']['name']:
             c.text((0, 9), f"File: {current_data['job']['file']['name']}")
             
             print_time = get_time_from_seconds(
                 current_data['progress']['printTime'] or 0)
             c.text((0, 18), f"Time: {print_time}")
             
-            filament = (current_data['job']['filament']['tool0']
-                        if 'tool0' in current_data['job']['filament']
-                        else current_data['job']['filament'])
+            filament = (PRINTER.job['filament']['tool0']
+                        if 'tool0' in PRINTER.job['filament']
+                        else PRINTER.job['filament'])
             filament_length = float_count_formatter(
                 (filament['length'] or 0) / 1000, 3)
             filament_mass = float_count_formatter(
                 (filament['volume'] or 0), 3)
             c.text((0, 27), f"Filament: {filament_length}m/{filament_mass}cm3")
 
-            # TODO: Add DisplayLayerProgress data
+            # Display height if information available from DisplayLayerProgress
+            height = (f"{self.display_layer_progress['current_height']:>5.1f}"
+                      f"/{self.display_layer_progress['total_height']:>5.1f}")
+            layer = (f"{self.display_layer_progress['current_layer']:4d}"
+                     f"/{self.display_layer_progress['total_layer']:4d}")
+            height_text = ""
+            if (self.display_layer_progress['current_height'] != -1.0
+                and self.display_layer_progress['current_layer'] != -1):
+                height_text = f"{layer};{height}"
+            elif self.display_layer_progress['current_layer'] != -1:
+                height_text = layer
+            elif self.display_layer_progress['current_height'] != -1.0:
+                height_text = height
+            if height_text:
+                c.text((0, 36), height_text)
             
         else:
             c.text((0, 18), "Waiting for file...")
-            
 
+        return c.image
+            
+    EVENTS = [
+        Events.DISCONNECTED, Events.CONNECTED, Events.CONNECTING,
+        Events.CONNECTIVITY_CHANGED, Events.DISCONNECTING,
+        Events.Z_CHANGE, Events.PRINTER_STATE_CHANGED, Events.PRINT_FAILED,
+        Events.PRINT_DONE, Events.PRINT_CANCELLED, Events.PRINT_CANCELLING,
+        Events.PRINT_PAUSED, Events.PRINT_RESUMED,
+        "DisplayLayerProgress_heightChanged",
+        "DisplayLayerProgress_layerChanged"
+    ]
+
+    def handle_event(self, event, payload):
+        if event in (Events.PRINT_FAILED, Events.PRINT_DONE,
+                     Events.PRINT_CANCELLED, Events.PRINT_CANCELLING):
+            self.display_layer_progress = {
+                'current_height': -1.0, 'current_layer': -1,
+                'total_height': -1.0, 'total_layer': -1
+            }
+        elif event in ("DisplayLayerProgress_heightChanged",
+                       "DisplayLayerProgress_layerChanged"):
+            self.display_layer_progress = {
+                'current_height': (float(payload.get('currentHeight'))
+                                   if payload.get('currentHeight') != "-"
+                                   else -1.0),
+                'current_layer': (int(payload.get('currentLayer'))
+                                  if payload.get('currentLayer') != "-"
+                                  else -1),
+                'total_height': float(payload.get('totalHeight')),
+                'total_layer': int(payload.get('totalLayer'))
+            }
+            
+        return {'DRAW'}
+
+    
 class PrinterStatusBarScreen(base.MicroPanelScreenBase):
-    # from update_ui_bottom()
-    pass
+    def draw(self):
+        c = self.get_canvas()
+        display_string = ""
+        if not PRINTER:
+            display_string = "Unavailable"
+        elif PRINTER.is_disconnected:
+            display_string = "Printer Not Connected"
+        elif PRINTER.flags['paused'] or PRINTER.flags['pausing']:
+            display_string = "Paused"
+        elif PRINTER.flags['cancelling']:
+            display_string = "Cancelling"
+        elif PRINTER.flags['ready'] and (PRINTER.progress['completion'] < 100):
+            if PRINTER.job['file']['name']:
+                display_string = "Ready to Start"
+            else:
+                display_string = "Waiting for Job"
+
+        if display_string:
+            c.text_centered(4, display_string)
+            return c.image
+        ###
+        ### Draw the progress bar
+        
+        percentage = PRINTER.progress['completion']
+        print_time = PRINTER.progress['printTime'] or 0
+        time_left = PRINTER.progress['printTimeLeft'] or 0
+
+        # Calculate progress from time
+        if self.settings.get_boolean(['timebased_progress']) and print_time:
+            percentage = (print_time * 100) / (print_time + time_left)
+
+        # Progress bar
+        c.rectangle((0, 0, self.width - 1, 5), fill=0, outline=255, width=1)
+        bar_width = int((self.width - 5) * (percentage / 100))
+        c.rectangle((2, 2, bar_width, 3), fill=255, outline=255, width=1)
+
+        # Percentage and ETA
+        c.text((0, 5), f"{percentage:.0f}%")
+        eta = time.strftime(self.settings.get(["eta_strftime"], merged=True),
+                            time.localtime(time.time() + time_left))
+        c.text_right(5, eta)
+
+        return c.image
+
+    EVENTS = [
+        Events.DISCONNECTED, Events.CONNECTED, Events.CONNECTING,
+        Events.CONNECTIVITY_CHANGED, Events.DISCONNECTING,
+        Events.Z_CHANGE, Events.PRINTER_STATE_CHANGED, Events.PRINT_FAILED,
+        Events.PRINT_DONE, Events.PRINT_CANCELLED, Events.PRINT_CANCELLING,
+        Events.PRINT_PAUSED, Events.PRINT_RESUMED,
+    ]
+
+    def handle_event(self, event, payload):
+        return {'DRAW'}
+    
+
+class JobCancelScreen(base.MicroPanelScreenBase):
+    def __init__(self, *args, **kwargs):
+        self.press_time = monotonic_time()
+        self.expired = False
+        self.timer = threading.Timer(10, self.timer_expired)
+        self.timer.start()
+        
+    def draw(self):
+        c = self.get_canvas()
+        c.text_centered(0, ("Cancel Print?\n"
+                            "Press 'X' to confirm\n"
+                            "Press any button or\n"
+                            "wait 10 sec to escape"))
+        return c.image
+
+    def handle_button(self, label):
+        if label == 'cancel':
+            if self.expired or (monotonic_time() - self.press_time) < 1.0:
+                return {'IGNORE'}
+            
+            PRINTER.cancel_print()
+
+        self.expired = True
+        return {'BACK'}
+
+    EXPIRED_EVENT = 'MicroPanel_JobCancelScreenExpired'
+        
+    def timer_expired(self):
+        if not self.expired:
+            # disable button, just in case there's a last minute race
+            self.expired = True
+            # send an event to myself
+            eventManager().fire(self.EXPIRED_EVENT)
+        
+    EVENTS = [EXPIRED_EVENT]
+    
+    def handle_event(self, event, payload):
+        if event == self.EXPIRED_EVENT:
+            return {'BACK'}

--- a/octoprint_display_panel/screens/printer.py
+++ b/octoprint_display_panel/screens/printer.py
@@ -195,7 +195,7 @@ class PrintStatusScreen(base.MicroPanelScreenBase):
                 'total_height': (float(payload.get('totalHeight'))
                                  if payload.get('totalHeight') != "-"
                                  else -1.0),
-                'total_layer': (int(payload.get('totalLayer')
+                'total_layer': (int(payload.get('totalLayer'))
                                 if payload.get('totalLayer') != "-" 
                                 else -1)
             }

--- a/octoprint_display_panel/screens/printer.py
+++ b/octoprint_display_panel/screens/printer.py
@@ -1,0 +1,79 @@
+
+
+from . import base
+
+
+# TODO: either fully implement this or think of some other way to get
+#       _printer from the main plugin up to this module
+#
+#class OctoPrintPrinterProxy:
+#    def __init__(self):
+#        self._printer = None
+#
+#    def __getattr__(self, key):
+#        if self._printer:
+#            return getattr(self._printer, key)
+#
+#    def set(self, printer):
+#        self._printer = printer
+#        
+#PRINTER = OctoPrintPrinterProxy()
+
+
+class PrinterInfoScreen(base.MicroPanelScreenBase):
+    def draw(self):
+        c = self.get_canvas()
+        c.text((0, 0), "Printer Temperatures")
+        head_text = "no printer"
+        bed_text = "no printer"
+        
+        if PRINTER.get_current_connection()[0] != 'Closed':
+            temperatures = PRINTER.get_current_temperatures()
+            tool = temperatures['tool0']
+            if tool:
+                head_text = f"{tool['actual']} / {tool['target']}\xb0C"
+            else:
+                head_text = "no tool"
+                
+            bed = temperatures['bed']
+            if bed:
+                bed_text = f"{bed['actual']} / {bed['target']}\xb0C"
+            else:
+                bed_text = "no bed"
+        c.text((0, 9), head_text)
+        c.text((0, 18), bed_text)
+
+        return c.image
+
+
+class PrintStatusScreen(base.MicroPanelScreenBase):
+    def draw(self):
+        c = self.get_canvas()
+        c.text((0, 0), f"State: {PRINTER.get_state_string()}")
+
+        current_data = PRINTER.get_current_data()
+        if current_data['job']['file']['name']:
+            c.text((0, 9), f"File: {current_data['job']['file']['name']}")
+            
+            print_time = get_time_from_seconds(
+                current_data['progress']['printTime'] or 0)
+            c.text((0, 18), f"Time: {print_time}")
+            
+            filament = (current_data['job']['filament']['tool0']
+                        if 'tool0' in current_data['job']['filament']
+                        else current_data['job']['filament'])
+            filament_length = float_count_formatter(
+                (filament['length'] or 0) / 1000, 3)
+            filament_mass = float_count_formatter(
+                (filament['volume'] or 0), 3)
+            c.text((0, 27), f"Filament: {filament_length}m/{filament_mass}cm3")
+
+            # TODO: Add DisplayLayerProgress data
+            
+        else:
+            c.text((0, 18), "Waiting for file...")
+            
+
+class PrinterStatusBarScreen(base.MicroPanelScreenBase):
+    # from update_ui_bottom()
+    pass

--- a/octoprint_display_panel/screens/printer.py
+++ b/octoprint_display_panel/screens/printer.py
@@ -1,3 +1,5 @@
+"""Printer-centric Micro Panel screens.
+"""
 import time
 import threading
 from octoprint.events import Events, eventManager
@@ -10,6 +12,13 @@ logger = logging.getLogger('octoprint.plugins.display_panel.screens.printer')
 
 
 class PrinterHelper:
+    """This class offers a few helpers to access commonly used data.
+
+    It normally proxies all attribute accesses to its `_printer`
+    instance variable, so for most purposes it can be treated
+    equivalently to the `_printer` instance.
+
+    """
     def __init__(self, _printer):
         self._printer = _printer
 
@@ -65,6 +74,8 @@ def float_count_formatter(number, max_chars):
 
 
 class PrinterInfoScreen(base.MicroPanelScreenBase):
+    """Base Information about the printer (temperatures)
+    """
     def __init__(self, width, height, _printer):
         super().__init__(width, height)
         self._printer = _printer
@@ -104,6 +115,8 @@ class PrinterInfoScreen(base.MicroPanelScreenBase):
     
 
 class PrintStatusScreen(base.MicroPanelScreenBase):
+    """Status information about the printer and any active print job.
+    """
     def __init__(self, width, height, _printer):
         super().__init__(width, height)
         self._printer = _printer
@@ -187,6 +200,8 @@ class PrintStatusScreen(base.MicroPanelScreenBase):
 
     
 class PrinterStatusBarScreen(base.MicroPanelScreenBase):
+    """The common status bar, showing either printer state or job progress.
+    """
     def __init__(self, width, height, _printer, _settings):
         super().__init__(width, height)
         self._printer = _printer
@@ -255,7 +270,15 @@ class PrinterStatusBarScreen(base.MicroPanelScreenBase):
     
 
 class JobCancelScreen(base.MicroPanelScreenBase):
-    def __init__(self, *args, **kwargs):
+    """The job cancel screen.
+    
+    This screen is shown by the MicroPanelScreenTop when the cancel
+    button is pressed.
+
+    """
+    def __init__(self, width, height, _printer):
+        super().__init__(width, height)
+        self._printer = _printer
         self.press_time = monotonic_time()
         self.expired = False
         self.timer = threading.Timer(10, self.timer_expired)
@@ -279,6 +302,10 @@ class JobCancelScreen(base.MicroPanelScreenBase):
         self.expired = True
         return {'BACK'}
 
+    # A synthetic event, defined below, is fired when the 10 second
+    # timer expires. This event is needed in order to make the plugin
+    # core aware that the screen needs to be redrawn.
+    
     EXPIRED_EVENT = 'MicroPanel_JobCancelScreenExpired'
         
     def timer_expired(self):

--- a/octoprint_display_panel/screens/printer.py
+++ b/octoprint_display_panel/screens/printer.py
@@ -192,8 +192,12 @@ class PrintStatusScreen(base.MicroPanelScreenBase):
                 'current_layer': (int(payload.get('currentLayer'))
                                   if payload.get('currentLayer') != "-"
                                   else -1),
-                'total_height': float(payload.get('totalHeight')),
-                'total_layer': int(payload.get('totalLayer'))
+                'total_height': (float(payload.get('totalHeight'))
+                                 if payload.get('totalHeight') != "-"
+                                 else -1.0),
+                'total_layer': (int(payload.get('totalLayer')
+                                if payload.get('totalLayer') != "-" 
+                                else -1)
             }
             
         return {'DRAW'}

--- a/octoprint_display_panel/screens/system.py
+++ b/octoprint_display_panel/screens/system.py
@@ -1,3 +1,5 @@
+"""System-centric Micro Panel screen.
+"""
 import time
 import psutil
 import shutil
@@ -7,6 +9,8 @@ from . import base
 
 
 class SystemInfoScreen(base.MicroPanelScreenBase):
+    """The common system information screen - IP, memory, etc.
+    """
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.stats = {}
@@ -27,7 +31,6 @@ class SystemInfoScreen(base.MicroPanelScreenBase):
         c.text((0, 9), f'L: {load[0]:.2f}, {load[1]:.2f}, {load[2]:.2f}')
         c.text((0, 18), (f'M: {mem.used//MB}/{mem.total//MB} MB'
                          f' {mem.percent}%'))
-        
         c.text((0, 27), (f'D: {disk.used//GB}/{disk.total//GB} GB'
                          f' {disk_percent:.1f}%'))
         return c.image
@@ -39,12 +42,16 @@ class SystemInfoScreen(base.MicroPanelScreenBase):
         self.last_stats = time.time()
         
         try:
+            # This technique gives a reliable reading on the system's
+            # externally visible IP address, but requires that
+            # external connectivity is online.
             s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
             s.connect(("8.8.8.8", 80))
             self.stats['ip'] = s.getsockname()[0]
             s.close()
         except OSError:
             self.stats['ip'] = 'IP unavailable'
+        
         try:
             self.stats['load'] = psutil.getloadavg()
         except OSError:

--- a/octoprint_display_panel/screens/system.py
+++ b/octoprint_display_panel/screens/system.py
@@ -1,0 +1,50 @@
+import time
+
+from . import base
+
+
+class SystemInfoScreen(base.MicroPanelScreenBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.stats = {}
+        self.last_stats = 0
+        self.get_stats()
+        
+    def draw(self):
+        self.get_stats()
+        load = self.stats['load']
+        memory = self.stats['memory']
+        disk = self.stats['disk']
+        disk_percent = (disk.used / disk.total) * 100.0
+        
+        c = self.get_canvas()
+        c.text_centered(0, ip)
+        c.text((0, 9), f'L: {load[0]:.2f} {load[1]:.2f} {load[2]:.2f}')
+        c.text((0, 18), (f'M: {mem.used//MB}/{mem.total//MB} MB'
+                         f' {mem.percent}%'))
+        
+        c.text((0, 27), (f'D: {disk.used//GB}/{disk.total//GB} GB'
+                         f' {disk_percent:.1f}%'))
+        return c.image
+               
+    def get_stats(self):
+        # Only get stats every 5 seconds
+        if (time.time() - self.last_stats) < 5:
+            return
+        self.last_stats = time.time()
+        
+        try:
+            s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            s.connect(("8.8.8.8", 80))
+            self.stats['ip'] = s.getsockname()[0]
+            s.close()
+        except OSError:
+            self.stats['ip'] = 'IP unavailable'
+        try:
+            self.stats['load'] = psutil.getloadavg()
+        except OSError:
+            self.stats['load'] = (-1, 0, 0)
+        self.stats['memory'] = psutil.virtual_memory()
+        self.stats['disk'] = shutil.disk_usage('/')
+        
+    

--- a/octoprint_display_panel/screens/system.py
+++ b/octoprint_display_panel/screens/system.py
@@ -1,4 +1,7 @@
 import time
+import psutil
+import shutil
+import socket
 
 from . import base
 
@@ -13,13 +16,15 @@ class SystemInfoScreen(base.MicroPanelScreenBase):
     def draw(self):
         self.get_stats()
         load = self.stats['load']
-        memory = self.stats['memory']
+        mem = self.stats['memory']
         disk = self.stats['disk']
         disk_percent = (disk.used / disk.total) * 100.0
+        MB = 1048576
+        GB = MB * 1024
         
         c = self.get_canvas()
-        c.text_centered(0, ip)
-        c.text((0, 9), f'L: {load[0]:.2f} {load[1]:.2f} {load[2]:.2f}')
+        c.text_centered(0, self.stats['ip'])
+        c.text((0, 9), f'L: {load[0]:.2f}, {load[1]:.2f}, {load[2]:.2f}')
         c.text((0, 18), (f'M: {mem.used//MB}/{mem.total//MB} MB'
                          f' {mem.percent}%'))
         

--- a/octoprint_display_panel/templates/display_panel_settings.jinja2
+++ b/octoprint_display_panel/templates/display_panel_settings.jinja2
@@ -199,9 +199,9 @@
 				</div>
 				<div class="control-group">
 					<label class="control-label">{{ _('Progress on top:') }}</label>
-					<div class="controls" data-toggle="tooltip" title="{{ _('Show the Progress Bar at the top of the display. Useful for dual color screens.') }}">
+					<div class="controls" data-toggle="tooltip" title="{{ _('Show the Progress Bar at the top of the display. Useful for dual color screens. Changing this setting requires restarting OctoPrint.') }}">
 						<input class="input-checkbox" type="checkbox" data-bind="checked: settings.plugins.display_panel.progress_on_top">
-						<div class="help-block">{{ _('Show the Progress Bar at the top of the display. Useful for dual color screens.') }}</div>
+						<div class="help-block">{{ _('Show the Progress Bar at the top of the display. Useful for dual color screens. Changing this setting requires restarting OctoPrint.') }}</div>
 					</div>
 				</div>
 


### PR DESCRIPTION
## Description

This is the second of two parts of a refactoring series as discussed in #61. This part consists of:

- Creating a base class that all display screens can inherit from
- Creating individual screens for each display, with a separate screen for the status bar
- Connecting screens into a hierarchy using subscreens
- Adding helper classes for screen drawing and printer interaction

This PR is carefully designed to be independent of, and complementary to, the other PR in the refactoring series. It's recommended that both are merged at the same time, but it is not necessary.

## Checklist

- [x] Commit message describes the changes
- [x] Updated CHANGELOG.md "Unreleased" section with changes
