### PR TITLE
Correction for missing filament data (if Octoprint API is used like with Cura)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Handling of OctoPrint API prints, as filament data is not available then as estimators are postponed.
 
 ## [3.0.1] - 2021-04-11
 ### Changed

--- a/octoprint_display_panel/screens/printer.py
+++ b/octoprint_display_panel/screens/printer.py
@@ -135,15 +135,17 @@ class PrintStatusScreen(base.MicroPanelScreenBase):
             print_time = get_time_from_seconds(
                 self._printer.progress['printTime'] or 0)
             c.text((0, 18), f"Time: {print_time}")
-            
-            filament = (self._printer.job['filament']['tool0']
-                        if 'tool0' in self._printer.job['filament']
-                        else self._printer.job['filament'])
-            filament_length = float_count_formatter(
-                (filament['length'] or 0) / 1000, 3)
-            filament_mass = float_count_formatter(
-                (filament['volume'] or 0), 3)
-            c.text((0, 27), f"Filament: {filament_length}m/{filament_mass}cm3")
+
+            # logger.info(self._printer.job) - for debugging
+            if self._printer.job['filament'] is not None:
+                filament = (self._printer.job['filament']['tool0']
+                            if 'tool0' in self._printer.job['filament']
+                            else self._printer.job['filament'])
+                filament_length = float_count_formatter(
+                    (filament['length'] or 0) / 1000, 3)
+                filament_mass = float_count_formatter(
+                    (filament['volume'] or 0), 3)
+                c.text((0, 27), f"Filament: {filament_length}m/{filament_mass}cm3")
 
             # Display height if information available from DisplayLayerProgress
             height = (f"{self.display_layer_progress['current_height']:>5.1f}"


### PR DESCRIPTION
Handling of OctoPrint API prints, as filament data is not available then as estimators are postponed.

## Description


## Checklist

- [X ] Commit message describes the changes
- [X] Updated CHANGELOG.md "Unreleased" section with changes
