### PR TITLE
Soft Buttons and File Select menu screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Soft Buttons: a new screen allowing you to select from small snippets of GCODE such as "auto home", "cooldown", or your own custom bed leveling routine (kgutwin)
+- File Select: a new screen listing files and directories, allowing you to select your desired file from the printer (kgutwin)
 
 ## [3.0.2] - 2022-01-24
 ## Changed

--- a/octoprint_display_panel/__init__.py
+++ b/octoprint_display_panel/__init__.py
@@ -83,7 +83,7 @@ class Display_panelPlugin(octoprint.plugin.StartupPlugin,
 		EventHandlerPlugin lifecycle hook, called whenever an event is fired
 		"""
 
-		#self._logger.info("on_event: %s", event)
+		self._logger.info("on_event: %s", event)
 
 		self.set_printer_state(event)
 		
@@ -233,8 +233,9 @@ class Display_panelPlugin(octoprint.plugin.StartupPlugin,
 		self._logger.info("Initializing screens...")
 		try:
 		        self.top_screen = screens.MicroPanelScreenTop(
-			        self.width, self.height,
-			        self._printer, self._settings
+				self.width, self.height,
+				self._printer, self._settings,
+				self._file_manager
 		        )
 		except:
 			self._logger.exception("Failed to initialize screen")

--- a/octoprint_display_panel/__init__.py
+++ b/octoprint_display_panel/__init__.py
@@ -83,7 +83,7 @@ class Display_panelPlugin(octoprint.plugin.StartupPlugin,
 		EventHandlerPlugin lifecycle hook, called whenever an event is fired
 		"""
 
-		self._logger.info("on_event: %s", event)
+		#self._logger.info("on_event: %s", event)
 
 		self.set_printer_state(event)
 		
@@ -156,6 +156,8 @@ class Display_panelPlugin(octoprint.plugin.StartupPlugin,
 			progress_on_top	= False,		# Default is disabled
 			timebased_progress	= False,	# Default is disabled
 			virtual_panel = False, # Default is disabled
+			soft_buttons = [],
+			file_select_hide_complete = True,
 		)
 
 	def on_settings_save(self, data):
@@ -248,6 +250,7 @@ class Display_panelPlugin(octoprint.plugin.StartupPlugin,
 		"""
 		Take action on a button press with the given name (such as 'cancel' or 'play')
 		"""
+		#self._logger.info("Pressed button " + label)
 		try:
 			result = self.top_screen.process_button(label)
 			if 'DRAW' in result:

--- a/octoprint_display_panel/screens/__init__.py
+++ b/octoprint_display_panel/screens/__init__.py
@@ -12,7 +12,7 @@ implementing screens, see base.py.
 """
 from octoprint.events import Events
 
-from . import base, system, printer
+from . import base, system, printer, soft_buttons
 
 
 class MessageScreen(base.MicroPanelScreenBase):
@@ -41,9 +41,10 @@ class MicroPanelScreenTop(base.MicroPanelScreenBase):
     will not need this level of complexity.
 
     """
-    def __init__(self, width, height, _printer, _settings):
+    def __init__(self, width, height, _printer, _settings, _file_manager):
         self._printer = printer.PrinterHelper(_printer)
         self._settings = _settings
+        self._file_manager = _file_manager
 
         # Define the status bar screen, which is typically displayed.
         self.status_bar_height = 16
@@ -64,6 +65,11 @@ class MicroPanelScreenTop(base.MicroPanelScreenBase):
                                                  self._printer),
             'print': printer.PrintStatusScreen(width, self.subscreen_height,
                                                self._printer),
+            'softbuttons': soft_buttons.SoftButtonsScreen(
+                width, self.subscreen_height, self._printer, self._settings),
+            'fileselect': soft_buttons.FileSelectScreen(
+                width, self.subscreen_height, self._printer,
+                self._file_manager),
         }
         self.current_screen = 'system'
         self.set_subscreen(self.current_screen)

--- a/octoprint_display_panel/screens/__init__.py
+++ b/octoprint_display_panel/screens/__init__.py
@@ -69,7 +69,7 @@ class MicroPanelScreenTop(base.MicroPanelScreenBase):
                 width, self.subscreen_height, self._printer, self._settings),
             'fileselect': soft_buttons.FileSelectScreen(
                 width, self.subscreen_height, self._printer,
-                self._file_manager),
+                self._file_manager, self._settings),
         }
         self.current_screen = 'system'
         self.set_subscreen(self.current_screen)
@@ -199,11 +199,12 @@ class MicroPanelScreenTop(base.MicroPanelScreenBase):
         if self.status_bar_screen.wants_event(event):
             r.update(self.status_bar_screen.process_event(event, payload))
 
-        # and pass it to the print status screen, if it isn't being displayed
-        if self.screens['print'].wants_event(event):
-            if self.subscreen != self.screens['print']:
-                # don't propagate its response, because it's not on screen
-                self.screens['print'].process_event(event, payload)
+        # and pass it to certain subscreens, if it isn't being displayed
+        for screen in ('print', 'fileselect', 'softbuttons'):
+            if self.screens[screen].wants_event(event):
+                if self.subscreen != self.screens[screen]:
+                    # don't propagate its response, because it's not on screen
+                    self.screens[screen].process_event(event, payload)
             
         r.update(super().process_event(event, payload))
         return r

--- a/octoprint_display_panel/screens/soft_buttons.py
+++ b/octoprint_display_panel/screens/soft_buttons.py
@@ -1,0 +1,107 @@
+import os.path
+from octoprint.events import Events
+
+from . import base
+
+from logging import getLogger
+
+
+class SoftButtonsScreen(base.MicroPanelScreenScroll):
+    _logger = getLogger('octoprint.plugins.display_panel.soft_buttons')
+    
+    def __init__(self, width, height, _printer, _settings):
+        menu = [
+            'Auto Home',
+            'Bed Leveling',
+            'Filament Unload',
+            'Filament Load',
+            'Cooldown'
+        ]
+        super().__init__(width, height, 'Soft Buttons', menu)
+        self._printer = _printer
+        self._settings = _settings
+        
+    def handle_menu_item(self, menu_item):
+        if self._printer.is_disconnected():
+            return
+        
+        if menu_item == 'Auto Home':
+            self._printer.commands('G28')
+        elif menu_item == 'Bed Leveling':
+            self._printer.commands([
+                'M140 S50', 'G28', 'M190',
+                'G0 X30 Y30 Z1', 'G0 Z0', 'M0 Point 1',
+                'G0 X30 Y200 Z1', 'G0 Z0', 'M0 Point 2',
+                'G0 X200 Y200 Z1', 'G0 Z0', 'M0 Point 3',
+                'G0 X200 Y30 Z1', 'G0 Z0', 'M0 Point 4',
+                'G28'
+            ])
+        elif menu_item == 'Filament Load':
+            self._printer.commands('M701 L10')
+        elif menu_item == 'Filament Unload':
+            self._printer.commands('M702 U10')
+        elif menu_item == 'Cooldown':
+            self._printer.commands(['M104 S0', 'M140 S0'])
+        return {'DRAW'}
+
+
+class FileSelectScreen(base.MicroPanelScreenScroll):
+    _logger = getLogger('octoprint.plugins.display_panel.file_select')
+    
+    def __init__(self, width, height, _printer, _file_manager):
+        self._printer = _printer
+        self._file_manager = _file_manager
+        self.folder = ""
+        super().__init__(width, height, 'File Select', [])
+        self.refresh_menu()
+        
+    def refresh_menu(self):
+        m = {}
+        files = self._file_manager.list_files(destinations='local',
+                                              path=self.folder)['local']
+        if self.folder:
+            m['../'] = 9e999
+        for name, metadata in files.items():
+            self._logger.info(f'{name}: {repr(metadata)}')
+            if 'type' not in metadata:
+                continue
+            # skip files which have completed successfully
+            if 'history' in metadata and any(h.get('success')
+                                             for h in metadata['history']):
+                continue
+            if metadata['type'] == 'folder':
+                m[name + '/'] = 9e999
+            elif metadata['type'] == 'machinecode':
+                m[name] = metadata['date']
+            # TODO: support type == 'model', aka stl
+        current_selection = (
+            self.menu[self.selection] if self.menu else None
+        )
+        self.menu = [
+            k for k, v in sorted(m.items(), key=(lambda i: (-i[1], i[0])))
+        ]
+        if current_selection in self.menu:
+            self.selection = self.menu.index(current_selection)
+        else:
+            self.selection = 0
+
+    EVENTS = [Events.UPDATED_FILES]
+            
+    def handle_event(self, event, payload):
+        self.refresh_menu()
+
+    def handle_menu_item(self, menu_item):
+        if menu_item.endswith('/'):
+            self.folder = os.path.normpath(
+                os.path.join(self.folder, menu_item.rstrip('/')))
+            if self.folder == '.':
+                self.folder = ''
+            self.refresh_menu()
+            return {'DRAW'}
+
+        if self._printer.is_disconnected():
+            return
+
+        self._printer.select_file(menu_item, False, printAfterSelect=False)
+        return {'DRAW'}
+        

--- a/octoprint_display_panel/templates/display_panel_settings.jinja2
+++ b/octoprint_display_panel/templates/display_panel_settings.jinja2
@@ -5,6 +5,7 @@
 		<ul class="nav nav-tabs" id="display_panel_tabs">
 			<li class="active"><a data-toggle="tab" href="#display_panel_buttons">Buttons</a></li>
 			<li><a data-toggle="tab" href="#display_panel_display">Display</a></li>
+			<li><a data-toggle="tab" href="#display_panel_soft_buttons">Soft Buttons</a></li>
 		</ul>
 
 		<div class="tab-content">
@@ -211,6 +212,35 @@
 						<div class="help-block">{{ _('Add a Micro Panel tab to the OctoPrint WebUI which mirrors the physical display. Changing this setting requires restarting OctoPrint.') }}</div>
 					</div>
 				</div>
+
+			</div>
+
+			<div id="display_panel_soft_buttons" class="tab-pane">
+				<div data-bind="foreach: settings.plugins.display_panel.soft_buttons">
+					<div class="control-group">
+						<label class="control-label"><input type="text" style="width:8em" placeholder="Label" data-bind="value: label"></label>
+						<div class="controls">
+							<div class="input-prepend">
+						     		<span class="add-on">GCode</span>
+								<input type="text" data-bind="value: gcode" placeholder="G28">
+							</div>
+							<button class="btn" data-bind="click: (me) => {$parent.settings.plugins.display_panel.soft_buttons.remove(me);}">Remove</button>
+						</div>
+					</div>
+				</div>
+
+				<button class="btn btn-primary" data-bind="click: () => {settings.plugins.display_panel.soft_buttons.push({label: '', gcode: ''});}">Add a Soft Button</button>
+
+				<hr>
+
+				<div class="control-group">
+					<label class="control-label">{{ _('Hide completed files:') }}</label>
+					<div class="controls" data-toggle="tooltip" title="{{ _('In the file selection screen, do not show successfully printed files.') }}">
+						<input class="input-checkbox" type="checkbox" data-bind="checked: settings.plugins.display_panel.file_select_hide_complete">
+						<div class="help-block">{{ _('In the file selection screen, do not show successfully printed files.') }}</div>
+					</div>
+				</div>
+
 
 			</div>
 


### PR DESCRIPTION
## Description

This PR adds two new screens to the existing screen set. Both of these screens are styled as "scrollable menus", and while they are visible, the function of the X (cancel) and = (pause) buttons are redefined to "scroll up" and "scroll down", while the > (play) button is defined as "select". The M (menu) button retains its function of paging through the screens. This is very intuitive for the standard panel button configuration. I've been using these screens for nearly a year now and they have been incredibly helpful to me.

### Soft Buttons

This is roughly analogous to plugins such as [Physical Buttons](https://plugins.octoprint.org/plugins/physicalbutton/) which allow you to do things through OctoPrint via a button, but without needing to have dedicated hardware. You can define your own Soft Buttons via the OctoPrint settings dialog, and they will appear as selectable items in a list. Currently, only GCODE is implemented as a button type, although other types (such as invoking OctoPrint commands or running specific files) can be done later. I'm using this to have access to some important functions like auto home, filament change, cooldown, and a custom bed leveling routine.

### File Select

This allows users to select the desired file to print from the panel. By default, successfully printed files are hidden, although that can be changed by a setting checkbox. This is very useful to me as my typical workflow involves sending my file to OctoPrint first before walking away from my computer to turn my printer on. With this screen, I can easily pick my desired file from those I've recently sent without needing to fiddle with a mobile device.

## Checklist

- [x] Commit message describes the changes
- [x] Updated CHANGELOG.md "Unreleased" section with changes
